### PR TITLE
Move standard Debian Stretch repos to wb-configs

### DIFF
--- a/rootfs/create_rootfs.sh
+++ b/rootfs/create_rootfs.sh
@@ -360,6 +360,9 @@ chr apt-get clean
 rm -rf ${OUTPUT}/run/* ${OUTPUT}/var/cache/apt/archives/* ${OUTPUT}/var/lib/apt/lists/*
 
 rm -f ${OUTPUT}/etc/apt/sources.list.d/local.list
+if [[ ${RELEASE} == "stretch" ]]; then
+	rm -f ${OUTPUT}/etc/apt/sources.list
+fi
 
 # removing SSH host keys
 rm -f ${OUTPUT}/etc/ssh/ssh_host_* || /bin/true


### PR DESCRIPTION
Я так понимаю, лучше перед этим PR сначала вмержить PR в wb-configs, чтобы не было сборок, в которых вообще не прописаны репозитории.
С этим PR и исправленным wb-configs будет так:
```
root@wirenboard-AQZBLNTY:~# dpkg -s wb-configs | grep Version
Version: 1.82.1
root@wirenboard-AQZBLNTY:~# ls /etc/apt
apt.conf.d  preferences.d  sources.list.d  trusted.gpg	trusted.gpg.d
root@wirenboard-AQZBLNTY:~# cat /etc/apt/sources.list.d/debian-upstream.list 
deb http://deb.debian.org/debian/ stretch main
deb http://deb.debian.org/debian/ stretch-updates main
deb http://security.debian.org stretch/updates main
root@wirenboard-AQZBLNTY:~# apt update
Hit:1 http://security.debian.org stretch/updates InRelease
Ign:2 http://deb.debian.org/debian stretch InRelease                           
Hit:3 http://deb.debian.org/debian stretch-updates InRelease                   
Hit:4 http://deb.debian.org/debian stretch Release                             
Hit:5 http://releases.contactless.ru/stable/stretch stretch InRelease          
Hit:6 http://cdn-fastly.deb.debian.org/debian stretch-backports InRelease      
Reading package lists... Done
Building dependency tree        
Reading state information... Done
All packages are up to date.
root@wirenboard-AQZBLNTY:~# 
```