### PR TITLE
devenv: distribute runner script within container

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ development environment. It can be used as standalone script
 and can be downloaded separately:
 
 ```
-wget https://raw.githubusercontent.com/contactless/wirenboard/master/wbdev
+wget https://raw.githubusercontent.com/wirenboard/wirenboard/master/wbdev
 chmod +x wbdev
 ```
 

--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -51,6 +51,7 @@ ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
  
+COPY wbdev_second_half.sh /
 COPY build.sh /root/
 COPY rootfs /root/rootfs
 COPY boards /root/boards

--- a/devenv/Makefile
+++ b/devenv/Makefile
@@ -11,6 +11,7 @@ upentry:
 	docker rm -f wbdevenv_tmp 2>/dev/null >/dev/null || true
 	docker run --name wbdevenv_tmp --entrypoint /bin/bash $(WBDEV_IMAGE)
 	docker cp entrypoint.sh wbdevenv_tmp:/sbin/entrypoint.sh
+	docker cp wbdev_second_half.sh wbdevenv_tmp:/wbdev_second_half.sh
 	docker cp projects.list wbdevenv_tmp:/projects.list
 	docker cp wbdev_profile.sh wbdevenv_tmp:/etc/profile.d/
 	docker commit --change 'ENTRYPOINT ["/sbin/entrypoint.sh"]' wbdevenv_tmp $(WBDEV_IMAGE)

--- a/devenv/entrypoint.sh
+++ b/devenv/entrypoint.sh
@@ -25,10 +25,36 @@ DEV_UID="${DEV_UID:-1000}"
 DEV_USER="${DEV_USER:-user}"
 DEV_GID="${DEV_GID:-$DEV_UID}"
 DEV_GROUP="${DEV_GROUP:-$DEV_USER}"
-DEV_DIR="${DEV_DIR:-}"
 ROOTFS=${ROOTFS:-"/rootfs/wheezy-armel"}
-TARGET_ARCH=${TARGET_ARCH:-armel}
-INSTALL_DEPS=${INSTALL_DEPS:-no}
+WBDEV_TARGET_ARCH=${WBDEV_TARGET_ARCH:-armel}
+WBDEV_INSTALL_DEPS=${WBDEV_INSTALL_DEPS:-no}
+WBDEV_TARGET_RELEASE=${WBDEV_INSTALL_DEPS:-"stretch"}
+WBDEV_TARGET=${WBDEV_TARGET:-""}
+
+# Parse parameters supplied via env variables
+case "$WBDEV_TARGET" in
+wheezy-armel)
+    WBDEV_TARGET_ARCH="armel"
+    WBDEV_TARGET_RELEASE="wheezy"
+    ;;
+wheezy-armhf)
+    WBDEV_TARGET_ARCH="armhf"
+    WBDEV_TARGET_RELEASE="wheezy"
+    ;;
+stretch-armhf|wb6)
+    WBDEV_TARGET_ARCH="armhf"
+    WBDEV_TARGET_RELEASE="stretch"
+    ;;
+stretch-armel|wb5)
+    WBDEV_TARGET_ARCH="armel"
+    WBDEV_TARGET_RELEASE="stretch"
+    ;;
+*)
+    echo "Warning: WBDEV_TARGET is not set or not supported, will use ${WBDEV_TARGET_RELEASE}-${WBDEV_TARGET_ARCH}"
+    ;;
+esac
+
+ROOTFS="/rootfs/${WBDEV_TARGET_RELEASE}-${WBDEV_TARGET_ARCH}"
 
 export WORKSPACE_DIR="/home/$DEV_USER/wbdev"
 export GOPATH="$WORKSPACE_DIR"/go
@@ -128,14 +154,14 @@ case "$cmd" in
         fi
         ;;
     ndeb)
-        if [ "$INSTALL_DEPS" = "yes" ]; then
+        if [ "$WBDEV_INSTALL_DEPS" = "yes" ]; then
             apt-get update || apt-get update # workaround for missing apt diff files
             mk-build-deps -ir -t "apt-get --force-yes -y"
         fi
         devsudo dpkg-buildpackage -us -uc "$@"
         ;;
     gdeb)
-        case "$TARGET_ARCH" in
+        case "$WBDEV_TARGET_ARCH" in
             armel)
                 devsudo CC=arm-linux-gnueabi-gcc dpkg-buildpackage -b -aarmel -us -uc "$@"
                 ;;
@@ -145,7 +171,7 @@ case "$cmd" in
         esac
         ;;
     hmake)
-        if [ "$INSTALL_DEPS" = "yes" ]; then
+        if [ "$WBDEV_INSTALL_DEPS" = "yes" ]; then
             apt-get update
             mk-build-deps -ir -t "apt-get --force-yes -y"
         fi
@@ -158,14 +184,14 @@ case "$cmd" in
         chu "$@"
         ;;
     make)
-        if [ "$INSTALL_DEPS" = "yes" ]; then
+        if [ "$WBDEV_INSTALL_DEPS" = "yes" ]; then
             chr apt-get update
             chr mk-build-deps -ir -t "apt-get --force-yes -y"
         fi
         chu make "$@"
         ;;
     cdeb)
-        if [ "$INSTALL_DEPS" = "yes" ]; then
+        if [ "$WBDEV_INSTALL_DEPS" = "yes" ]; then
             chr apt-get update
             chr mk-build-deps -ir -t "apt-get --force-yes -y"
         fi

--- a/wbdev
+++ b/wbdev
@@ -1,57 +1,8 @@
-#!/bin/bash
-DOCKER_TTY_OPTS=-i
-if [ -t 0 ]; then
-    DOCKER_TTY_OPTS=-it
-fi
-ssh_opts=
-if [ -n "$SSH_AUTH_SOCK" ]; then
-    ssh_opts="-e SSH_AUTH_SOCK=/ssh-agent -v $SSH_AUTH_SOCK:/ssh-agent"
-fi
-ROOTFS="/rootfs/stretch-armel"
-TARGET_ARCH="armel"
+#!/bin/bash -e
+WBDEV_IMAGE=${WBDEV_IMAGE:-contactless/devenv:latest}
 
-case "$WBDEV_TARGET" in
-wheezy-armel)
-    ROOTFS="/rootfs/wheezy-armel"
-    TARGET_ARCH="armel"
-    ;;
-stretch-armhf|wb6)
-    ROOTFS="/rootfs/stretch-armhf"
-    TARGET_ARCH="armhf"
-    ;;
-stretch-armel|wb5)
-    ROOTFS="/rootfs/stretch-armel"
-    TARGET_ARCH="armel"
-    ;;
-*)
-    echo "Warning: WBDEV_TARGET is not set or not supported, defaulting to stretch-armel (aka wb5)"
-    ;;
-esac
-
-IMAGE=${WBDEV_IMAGE:-contactless/devenv:latest}
-
-if [[ $OSTYPE == darwin* ]]
-then
-	VM_HOME="/home/$USER"
-else
-	VM_HOME=$HOME
-fi
-
-PREFIX="$VM_HOME/wbdev/go/src/github.com/contactless"
-
-INSTALL_DEPS=${WBDEV_INSTALL_DEPS:-no}
-
-docker run $DOCKER_TTY_OPTS --privileged --rm \
-       -e DEV_UID=$UID \
-       -e DEV_USER=$USER \
-       -e DEV_DIR="$PREFIX/${PWD##*/}" \
-       -e DEV_TERM="$TERM" \
-       -e ROOTFS="$ROOTFS" \
-       -e TARGET_ARCH="$TARGET_ARCH" \
-       -e INSTALL_DEPS="$INSTALL_DEPS" \
-       -v $HOME:$VM_HOME \
-       -v ${PWD%/*}:$PREFIX \
-       $ssh_opts \
-       -h wbdevenv \
-       $IMAGE \
-       "$@"
+FNAME=`mktemp /tmp/wbdev.sh.XXXXX`
+docker run --rm --entrypoint cat ${WBDEV_IMAGE} /wbdev_second_half.sh > ${FNAME}
+chmod a+x ${FNAME}
+${FNAME} "$@"
+rm ${FNAME}


### PR DESCRIPTION
внешний скрипт wbdev получается связан с версией контейнера, что неудобно. Запихнул wbdev внутрь контейнера, снаружи оставил только его вытаскивание из контейнера.

Кроме этого настоящий wbdev (который внутри контейнера) теперь только формирует параметры для докера и не пытается их обрабатывать. В entrypoint передаются как есть все переменные, начинающиеся на WBDEV_. Вся логика теперь в одном месте - внутри entrypoint.


wbdev script is now only extracts and executes actual runner
script from the container.
It's not supposed to be updated.

