### PR TITLE
/dev/ptmx is replaced by symlink to /dev/pts/ptmx

### DIFF
--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -61,6 +61,10 @@ EOF
 
 	#clean
 	schroot -c ${CHROOT_NAME} --directory=/ -- apt-get -y autoremove
+
+	# set correct symlink to /dev/ptmx
+	rm -f ${ROOTFS}/dev/ptmx
+	ln -s /dev/pts/ptmx ${ROOTFS}/dev/ptmx
 }
 
 do_build stretch armel 58


### PR DESCRIPTION
При генерации rootfs для sbuild заменяем /dev/ptmx на симлинк на /dev/pts/ptmx. Это решает проблему с ошибкой при вызове grantpt в тесте wb-mqtt-serial.