### PR TITLE
32964 qemu download source quickfix

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -31,8 +31,9 @@ RUN echo "deb [arch=amd64] http://releases.contactless.ru/stable/stretch stretch
 # FIXME: we should not install anything with --force-yes
  
 #add fresh qemu-user-static from backports
-RUN wget http://ftp.us.debian.org/debian/pool/main/q/qemu/qemu-user-static_5.0-14~bpo10+1_amd64.deb && \
-    apt install -y ./qemu-user-static_5.0-14~bpo10+1_amd64.deb
+# FIXME: this should be installed from valid Wirenboard backports archive via apt-get
+RUN wget http://releases.contactless.ru/experimental/stretch/pool/main/q/qemu/qemu-user-static_5.2+dfsg-3~bpo10+1_amd64.deb && \
+    apt install -y ./qemu-user-static_5.2+dfsg-3~bpo10+1_amd64.deb
 # Go environment
 # from https://github.com/docker-library/golang/blob/master/1.5/Dockerfile
 ENV GOLANG_VERSION 1.13.1


### PR DESCRIPTION
В перспективе нужно будет складывать всё, что нам нужно в фиксированных версиях, в свой репозиторий, и тянуть оттуда нормальным способом через apt-get. Пока оставим так, чтобы devenv начал собираться.