### PR TITLE
devenv: use new repository

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -3,8 +3,7 @@ MAINTAINER ivan4th <ivan4th@gmail.com>
  
 ENV DEBIAN_FRONTEND noninteractive
  
-RUN echo "deb [arch=amd64] http://releases.contactless.ru/stable/stretch stretch main" > /etc/apt/sources.list.d/contactless.list && \
-    echo "deb [arch=amd64] http://deb.wirenboard.com/dev-tools stable main" > /etc/apt/sources.list.d/wirenboard-dev-tools.list && \
+RUN echo "deb [arch=amd64] http://deb.wirenboard.com/dev-tools stable main" > /etc/apt/sources.list.d/wirenboard-dev-tools.list && \
     sed -e "s/httpredir.debian.org/mirror.yandex.ru/g" -i /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y --allow-unauthenticated gnupg1 curl ca-certificates apt-transport-https contactless-keyring && \

--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -25,9 +25,22 @@ do_build_sbuild_env() {
 	schroot -c ${CHROOT_NAME} --directory=/ -- apt-get -y install libmosquittopp-dev:armhf libmosquitto-dev:armhf libmosquittopp-dev:armel libmosquitto-dev:armel e2fslibs-dev:armhf
 
 	#add conactless repo
-	echo "deb [arch=amd64,armhf,armel] http://releases.contactless.ru/stable/stretch stretch main" > ${ROOTFS}/etc/apt/sources.list.d/contactless.list
     echo "deb http://deb.wirenboard.com/dev-tools stable main" > ${ROOTFS}/etc/apt/sources.list.d/wirenboard-dev-tools.list
 	cp /usr/share/keyrings/contactless-keyring.gpg ${ROOTFS}/etc/apt/trusted.gpg.d/
+
+    cat <<EOF >${ROOTFS}/etc/apt/preferences.d/wb-releases
+Package: *
+Pin: o=wirenboard a=pool
+Pin-Priority: 10
+
+Package: *
+Pin: o=wirenboard a=unstable
+Pin-Priority: 990
+
+Package: *
+Pin: o=wirenboard
+Pin-Priority: 991
+EOF
 
 	schroot -c ${CHROOT_NAME} --directory=/ -- apt-get update
 


### PR DESCRIPTION
Переключил sbuild на новый репозиторий.

stable подключается по умолчанию в зависимости от того, под какой контроллер собираем. unstable можно подключить в дополнение к stable с пониженным приоритетом, установив переменную WBDEV_USE_UNSTABLE_DEPS.

Можно также собрать только с конкретным релизом, прописав его в WB_TARGET_REPO_RELEASE.