### PR TITLE
Add the ssh port forwarding for the wbdev

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ Set `WBDEV_BUILD_METHOD=qemuchroot` to use legacy qemu virtualized builds.
 Set nonzero value to `WBDEV_USE_EXPERIMENTAL_DEPS` or `WBDEV_USE_UNSTABLE_DEPS` to
 add experimental or unstable Wiren Board Debian repositories respectively.
 
+To forward the ssh port to the container, set `WBDEV_SSH_PORT_FORWARDING` variable
+to the value of the host's local port.
+
 If required, another Docker image could be set via
 environment variable WBDEV_IMAGE.
 

--- a/devenv/wbdev_second_half.sh
+++ b/devenv/wbdev_second_half.sh
@@ -10,6 +10,10 @@ if [ -n "$SSH_AUTH_SOCK" ]; then
     ssh_opts="-e SSH_AUTH_SOCK=/ssh-agent -v $SSH_AUTH_SOCK:/ssh-agent"
 fi
 
+ssh_port_forwarding=
+if [ -n "WBDEV_SSH_PORT_FORWARDING" ]; then
+   ssh_port_forward="-p $WBDEV_SSH_PORT_FORWARDING:22"
+fi
 
 if [[ $OSTYPE == darwin* ]]
 then
@@ -34,6 +38,7 @@ docker run $DOCKER_TTY_OPTS --privileged --rm \
        -e DEB_BUILD_OPTIONS \
        -v $HOME:$VM_HOME \
        -v ${PWD%/*}:$PREFIX \
+       $ssh_port_forwarding \
        $ssh_opts \
        -h wbdevenv \
        $WBDEV_IMAGE \

--- a/devenv/wbdev_second_half.sh
+++ b/devenv/wbdev_second_half.sh
@@ -12,7 +12,7 @@ fi
 
 ssh_port_forwarding=
 if [ -n "WBDEV_SSH_PORT_FORWARDING" ]; then
-   ssh_port_forward="-p $WBDEV_SSH_PORT_FORWARDING:22"
+   ssh_port_forwarding="-p $WBDEV_SSH_PORT_FORWARDING:22"
 fi
 
 if [[ $OSTYPE == darwin* ]]

--- a/devenv/wbdev_second_half.sh
+++ b/devenv/wbdev_second_half.sh
@@ -11,7 +11,7 @@ if [ -n "$SSH_AUTH_SOCK" ]; then
 fi
 
 ssh_port_forwarding=
-if [ -n "WBDEV_SSH_PORT_FORWARDING" ]; then
+if [ -n "$WBDEV_SSH_PORT_FORWARDING" ]; then
    ssh_port_forwarding="-p $WBDEV_SSH_PORT_FORWARDING:22"
 fi
 


### PR DESCRIPTION
Добавил проброс ssh порта в докер контейнер. 
Для включения нужно в переменную `WBDEV_SSH_PORT_FORWARDING` установить значение локального порта с которого осуществляется проброс на 22й порт контейнера.
Опция полезна для отладки и разработки.