### PR TITLE
ci: releaseImages: do not upload firmware IMGs by default

### DIFF
--- a/ci/pipelines/releaseImages.groovy
+++ b/ci/pipelines/releaseImages.groovy
@@ -58,7 +58,7 @@ pipeline {
                                       parameters: [
                                         string(name: 'IMAGE_BUILDNUMBER', value: currentImageJob.getId()),
                                         booleanParam(name: 'SET_LATEST', value: true),
-                                        booleanParam(name: 'PUBLISH_IMG', value: true)
+                                        booleanParam(name: 'PUBLISH_IMG', value: false)
                                       ])
                             }
                         }


### PR DESCRIPTION
Загружать IMG после внедрения нового стенда инициализации в целом больше не обязательно, там используются FIT по умолчанию