### PR TITLE
devenv: prepare for buillseye-backports

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -2,7 +2,13 @@ FROM debian:stretch
 MAINTAINER ivan4th <ivan4th@gmail.com>
  
 ENV DEBIAN_FRONTEND noninteractive
- 
+
+# clang-format was previously installed from LLVM nighly repository,
+# but we switched to fixed version 15.0.0-++20220704093357+5f0a054f8954-1~exp1~20220704093409.365
+# to avoid unexpected changes in our source code because of new bugs/fixes in llvm.
+#
+# It would be nice to update llvm from time to time though.
+
 RUN echo "deb [arch=amd64] http://deb.wirenboard.com/dev-tools stable main" > /etc/apt/sources.list.d/wirenboard-dev-tools.list && \
     sed -e "s/httpredir.debian.org/mirror.yandex.ru/g" -i /etc/apt/sources.list && \
     echo "deb [arch=amd64] http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/stretch-backports.list && \
@@ -12,8 +18,6 @@ RUN echo "deb [arch=amd64] http://deb.wirenboard.com/dev-tools stable main" > /e
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys AEE07869 && \
     echo 'deb [arch=amd64] http://repo.aptly.info/ squeeze main' >/etc/apt/sources.list.d/aptly.list && \
     curl https://www.aptly.info/pubkey.txt | apt-key add - && \ 
-    echo 'deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch main' >> /etc/apt/sources.list.d/clang.list && \
-    curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-get update && \
     apt-get install -y --force-yes git mercurial curl wget debootstrap \
       build-essential pkg-config debhelper    \

--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -7,6 +7,10 @@ ENV DEBIAN_FRONTEND noninteractive
 # but we switched to fixed version 15.0.0-++20220704093357+5f0a054f8954-1~exp1~20220704093409.365
 # to avoid unexpected changes in our source code because of new bugs/fixes in llvm.
 #
+# In order to make it work with wbci scripts (which treat ~exp substring in version
+# as a branch version and does not add it to the staging) ~exp was repaced with ~llvmexp
+# (manually using dpkg-dev and sed :) ) before uploading to WB dev-tools repo.
+#
 # It would be nice to update llvm from time to time though.
 
 RUN echo "deb [arch=amd64] http://deb.wirenboard.com/dev-tools stable main" > /etc/apt/sources.list.d/wirenboard-dev-tools.list && \

--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -46,16 +46,9 @@ ENV GOLANG_VERSION 1.13.1
 ENV GOLANG_DOWNLOAD_URL   https://dl.google.com/go/go$GOLANG_VERSION.linux-amd64.tar.gz
 ENV GOLANG_DOWNLOAD_SHA1  e9275a46508483242feb6200733b6382f127cb43
  
-ENV GLIDE_VERSION v0.13.1
-ENV GLIDE_DOWNLOAD_URL https://github.com/Masterminds/glide/releases/download/$GLIDE_VERSION/glide-$GLIDE_VERSION-linux-amd64.tar.gz
-ENV GLIDE_DOWNLOAD_SHA1 6de1d6931108ed94bf0f722dbd158487d8f75b20 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
   && tar -C /usr/local -xzf golang.tar.gz \
   && rm golang.tar.gz
- 
-RUN curl -fsSL "$GLIDE_DOWNLOAD_URL" -o glide.tar.gz \
-  && tar -C /usr/local/bin --strip-components=1 -xzf glide.tar.gz linux-amd64/glide \
-  && rm glide.tar.gz
  
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH

--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -52,8 +52,8 @@ EOF
 	elif [[ "$RELEASE" = "bullseye" ]]; then
 		echo "deb http://deb.debian.org/debian bullseye-backports main" > ${ROOTFS}/etc/apt/sources.list.d/bullseye-backports.list
         cat <<EOF >${ROOTFS}/etc/apt/preferences.d/bullseye-backports
-Package: *
-Pin: release a=stretch-backports
+Package: libnm0 libmbim-*:any libqmi-*:any gir1.2-mbim-1.0 git1.2-qmi-1.0
+Pin: release a=bullseye-backports
 Pin-Priority: 510
 EOF
 	fi

--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -41,14 +41,21 @@ Package: *:any
 Pin: release o=wirenboard
 Pin-Priority: 991
 EOF
-    cat <<EOF >${ROOTFS}/etc/apt/preferences.d/nodejs
+
+	if [[ "$RELEASE" = "stretch" ]]; then
+		echo "deb http://deb.debian.org/debian stretch-backports main" > ${ROOTFS}/etc/apt/sources.list.d/stretch-backports.list
+        cat <<EOF >${ROOTFS}/etc/apt/preferences.d/nodejs
 Package: node*:any npm:any libuv1*:any
 Pin: release a=stretch-backports
 Pin-Priority: 510
 EOF
-
-	if [[ "$RELEASE" = "stretch" ]]; then
-		echo "deb http://deb.debian.org/debian stretch-backports main" > ${ROOTFS}/etc/apt/sources.list.d/stretch-backports.list
+	elif [[ "$RELEASE" = "bullseye" ]]; then
+		echo "deb http://deb.debian.org/debian bullseye-backports main" > ${ROOTFS}/etc/apt/sources.list.d/bullseye-backports.list
+        cat <<EOF >${ROOTFS}/etc/apt/preferences.d/bullseye-backports
+Package: *
+Pin: release a=stretch-backports
+Pin-Priority: 510
+EOF
 	fi
 
 	schroot -c ${CHROOT_NAME} --directory=/ -- apt-get update


### PR DESCRIPTION
Добавил в bullseye репозиторий bullseye-backports (нужен для networkmanager / modemmanager и их зависимостей). Также немного починил логику конфигурирования sbuild через переменные, чтобы можно было задавать релиз и префикс нашего репозитория в умолчаниях.

**UPD 28.07.2022**: clang-format теперь устанавливается из репозитория WB dev-tools, куда был заботливо отправлен после небольшого косметического изменения в строку версии (`~exp` заменил на `~llvmexp`, чтобы не раздражать скрипты wbci этим)