### PR TITLE
New image names format

### DIFF
--- a/ci/pipelines/publishImage.groovy
+++ b/ci/pipelines/publishImage.groovy
@@ -13,7 +13,7 @@ pipeline {
         string(name: 'IMAGE_BUILDNUMBER', defaultValue: '', description: 'from pipelines/build-image')
         booleanParam(name: 'SET_LATEST', defaultValue: false, description: 'remove saved rootfs images before build')
         booleanParam(name: 'PUBLISH_IMG', defaultValue: true, description: 'works with SET_LATEST=true')
-        string(name: 'LATEST_NAME', defaultValue: 'latest_stretch', description: 'used to publish "latest_*.fit, .md5 and .img files')
+        string(name: 'LATEST_NAME', defaultValue: 'latest', description: 'used to publish "latest_*.fit, .md5 and .img files')
     }
     environment {
         S3CMD_CONFIG = credentials('s3cmd-fw-releases-config')
@@ -77,7 +77,6 @@ pipeline {
             environment {
                 FIT_MD5_NAME = "${params.LATEST_NAME}.fit.md5"
                 FIT_PUB_NAME = "${params.LATEST_NAME}.fit"
-                FIT_FRESET_PUB_NAME = "${params.LATEST_NAME}_FACTORYRESET.fit"
             }
             steps {
                 dir(env.TARGET_DIR) {
@@ -85,12 +84,10 @@ pipeline {
                     sh 's3cmd -c $S3CMD_CONFIG put $FIT_MD5_NAME ${S3_PREFIX}/${FIT_MD5_NAME}'
                     sh '''s3cmd -c $S3CMD_CONFIG put $FIT_NAME ${S3_PREFIX}/${FIT_PUB_NAME} \
                         --add-header="Content-Disposition: attachment; filename=\\"$FIT_NAME\\""'''
-                    sh '''s3cmd -c $S3CMD_CONFIG put $FIT_NAME ${S3_PREFIX}/${FIT_FRESET_PUB_NAME} \
-                        --add-header="Content-Disposition: attachment; filename=\\"$FIT_NAME\\""'''
                 }
             }
         }
-        // FIXME: this step is weird, better to use FITs in the future
+
         stage('Publish latest IMG') {
             when { expression {
                 params.PUBLISH_IMG && params.SET_LATEST

--- a/image/create_images.sh
+++ b/image/create_images.sh
@@ -57,7 +57,14 @@ if [ ! -z "$2" ]; then
     echo "FW version overriden: $VERSION"
 fi
 
-FULL_VERSION="${VERSION}_${SUITE}"
+# for stable, add release name to fit filename (e.g. wb-2207).
+# for testing/unstable there may be no proper release name, so keep suite name
+FIT_RELEASE_NAME=${SUITE}
+if [ "$FIT_RELEASE_NAME" = "stable" ]; then
+    FIT_RELEASE_NAME=${RELEASE_NAME}
+fi
+
+FULL_VERSION="${VERSION}_${FIT_RELEASE_NAME}_${VERSION_CODENAME}"
 if [[ -n "$REPO_PREFIX" ]]; then
     FULL_VERSION="${FULL_VERSION}_$(echo $REPO_PREFIX | sed -e 's/\W/+/g' -e 's/_/+/g')"
 fi
@@ -65,7 +72,7 @@ fi
 OUT_DIR=${OUT_DIR:-"${IMAGES_DIR}/${VERSION}"}
 mkdir -p ${OUT_DIR}
 IMG_NAME="${OUT_DIR}/${FULL_VERSION}_emmc_wb${BOARD}.img"
-WEBUPD_NAME="${OUT_DIR}/${FULL_VERSION}_webupd_wb${BOARD}.fit"
+WEBUPD_NAME="${OUT_DIR}/${FULL_VERSION}_wb${BOARD}.fit"
 
 if  [ -n "$MAKE_IMG" ]; then
     echo "Create IMG"


### PR DESCRIPTION
В имена FIT-образов теперь включена версия релиза (если собирается образ из stable), а также релиз debian (stretch или bullseye). Последняя версия теперь называется latest.fit по умолчанию (чтобы latest_stretch.fit не получился с bullseye). `latest_stretch.fit` всё ещё можно будет опубликовать вручную.

Также больше не публикуется `latest_stretch_FACTORYRESET.fit`, всё равно смысла в нём не было.