### PR TITLE
Fix check-staging pipeline for bullseye

### DIFF
--- a/ci/pipelines/checkStaging.groovy
+++ b/ci/pipelines/checkStaging.groovy
@@ -16,9 +16,11 @@ pipeline {
         label "devenv"
     }
     parameters {
+        string(name: 'DEBIAN_RELEASE', defaultValue: 'bullseye', description: 'debian release')
         string(name: 'BOARDS', defaultValue: '67 7x', description: 'boards to build images for')
         string(name: 'WIRENBOARD_BRANCH', defaultValue: 'master', description: 'wirenboard/wirenboard repo branch')
         string(name: 'WBDEV_IMAGE', defaultValue: 'contactless/devenv:latest', description: 'tag for wbdev')
+        booleanParam(name: 'ADVANCE_UNSTABLE', defaultValue: true, description: 'disable if you want just to check')
         booleanParam(name: 'FORCE_OVERWRITE', defaultValue: false, description: 'use only if you know what you are doing')
     }
     stages {
@@ -50,29 +52,26 @@ pipeline {
             steps {
                 script {
                     def targets = params.BOARDS.split(' ')
-                    def jobs = [:]
 
                     for (target in targets) {
                         def currentTarget = target
-                        jobs["build ${currentTarget}"] = {
-                            stage("Build image for ${currentTarget}") {
-                                build job: 'pipelines/build-image', wait: true, parameters: [
-                                    string(name: 'BOARD', value: currentTarget),
-                                    string(name: 'WB_TARGET', value: 'all'),
-                                    string(name: 'WB_RELEASE', value: 'staging'),
-                                    booleanParam(name: 'SAVE_ARTIFACTS', value: false)
-                                ]
-                            }
+                        stage("Build image for ${currentTarget}") {
+                            build job: 'pipelines/build-image', wait: true, parameters: [
+                                string(name: 'DEBIAN_RELEASE', value: params.DEBIAN_RELEASE),
+                                string(name: 'BOARD', value: currentTarget),
+                                string(name: 'WB_TARGET', value: 'all'),
+                                string(name: 'WB_RELEASE', value: 'staging'),
+                                string(name: 'WIRENBOARD_BRANCH', value: params.WIRENBOARD_BRANCH),
+                                booleanParam(name: 'SAVE_ARTIFACTS', value: false)
+                            ]
                         }
                     }
-
-                    parallel jobs
                 }
             }
         }
         stage('Advance unstable') {
             when { expression {
-                changesDetected
+                changesDetected && params.ADVANCE_UNSTABLE
             }}
             environment {
                 APTLY_CONFIG = credentials('release-aptly-config')
@@ -86,7 +85,7 @@ pipeline {
         }
         stage('Upload via wb-releases') {
             when { expression {
-                changesDetected
+                changesDetected && params.ADVANCE_UNSTABLE
             }}
             steps {
                 build job: 'wirenboard/wb-releases/master', wait: true, parameters: [

--- a/rootfs/create_rootfs.sh
+++ b/rootfs/create_rootfs.sh
@@ -5,11 +5,6 @@ set -e
 ROOTFS_DIR=$ROOTFS
 DEBIAN_RELEASE=${DEBIAN_RELEASE:-bullseye}
 
-# FIXME: remove this when bullseye becomes stable
-if [[ ${DEBIAN_RELEASE} == "bullseye" ]]; then
-    WB_RELEASE=testing
-fi
-
 WB_REPO=${WB_REPO:-'http://deb.wirenboard.com/'}
 WB_REPO_PREFIX=${WB_REPO_PREFIX:-''}
 WB_TEMP_REPO=${WB_TEMP_REPO:-false}
@@ -120,7 +115,7 @@ FULL_REPO_URL=`echo "$WB_REPO/$WB_REPO_PREFIX/$WB_TARGET" | sed 's#//\+#/#g' | s
 WB_TARGET_FOR_FILENAME=`echo $WB_TARGET | sed 's#/#_#'`
 
 WB_REPO_HASH=`echo "$FULL_REPO_URL $ADD_REPOS" | sha256sum - | head -c 8`
-ROOTFS_BASE_SUFFIX="${WB_RELEASE}_${WB_TARGET_FOR_FILENAME}_r${WB_REPO_HASH}"
+ROOTFS_BASE_SUFFIX="${WB_RELEASE}_${WB_TARGET_FOR_FILENAME}_${DEBIAN_RELEASE}_r${WB_REPO_HASH}"
 ROOTFS_BASE_TARBALL="${WORK_DIR}/rootfs_base_${ROOTFS_BASE_SUFFIX}.tar.gz"
 
 ROOTFS_DIR=$OUTPUT
@@ -131,7 +126,7 @@ ADD_REPO_PIN_FILE=$OUTPUT/etc/apt/preferences.d/00-wb-additional-tmp
 APT_LIST_TMP_FNAME=${OUTPUT}/etc/apt/sources.list.d/wb-install-tmp.list
 APT_PIN_TMP_FNAME=${OUTPUT}/etc/apt/preferences.d/01wb-install-tmp
 
-REPO="http://mirror.yandex.ru/debian/"
+REPO="http://deb.debian.org/debian/"
 
 setup_additional_repos() {
     # setup additional repos

--- a/rootfs/rootfs_env.sh
+++ b/rootfs/rootfs_env.sh
@@ -53,7 +53,8 @@ chr_nofail() {
 }
 
 chr_apt_install() {
-    chr apt-get -o Dpkg::Options::=--force-confnew --force-yes install -y "$@"
+    chr apt-get -o Dpkg::Options::=--force-confnew --force-yes install -y "$@" ||
+        chr apt-get -o Debug::pkgProblemResolver=yes install -y "$@"
 }
 
 chr_apt_update() {


### PR DESCRIPTION
С переходом на bullseye пайплайн check-staging оказался сломанным, потому что пытался заставить build-image собирать неправильный образ. Этот патч исправляет ошибки.

Также здесь отключается параллельная сборка образов, чтобы не занимать чрезмерно очередь сборки в jenkins.