### PR TITLE
ci: make checkStaging pass WBDEV_IMAGE to buildImage

### DIFF
--- a/ci/pipelines/checkStaging.groovy
+++ b/ci/pipelines/checkStaging.groovy
@@ -62,6 +62,7 @@ pipeline {
                                 string(name: 'WB_TARGET', value: 'all'),
                                 string(name: 'WB_RELEASE', value: 'staging'),
                                 string(name: 'WIRENBOARD_BRANCH', value: params.WIRENBOARD_BRANCH),
+                                string(name: 'WBDEV_IMAGE', value: params.WBDEV_IMAGE),
                                 booleanParam(name: 'SAVE_ARTIFACTS', value: false)
                             ]
                         }


### PR DESCRIPTION
Эта опция оказалась сломанной, хотя по факту пригодилась