### PR TITLE
Fix devenv image build

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -25,7 +25,7 @@ Package: pylint python3-astroid python3-typing-extensions\nPin: release a=testin
     \
     apt update &&\
     apt install -y --force-yes git debootstrap proot build-essential pkg-config debhelper \
-       nodejs npm bash-completion nano gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf sudo locales \
+       nodejs bash-completion nano gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf sudo locales \
        devscripts python3-virtualenv git equivs qemu-user-static binfmt-support node-rimraf \
        libmosquittopp-dev libmosquitto-dev pkg-config gcc g++ libmodbus-dev debian-archive-keyring \
        libcurl4-gnutls-dev libsqlite3-dev libjsoncpp-dev sbuild kpartx zip device-tree-compiler \


### PR DESCRIPTION
```
#5 29.07 The following packages have unmet dependencies:
#5 29.22  libnode72 : Conflicts: nodejs-legacy
#5 29.22  nodejs : Conflicts: npm
#5 29.26 W: --force-yes is deprecated, use one of the options starting with --allow instead.
#5 29.26 E: Unable to correct problems, you have held broken packages.
```

Проверил билд homeui с новым контейнером.