### PR TITLE
image: pass FIT path to postinst scripts via env

### DIFF
--- a/image/install_update.sh
+++ b/image/install_update.sh
@@ -148,7 +148,7 @@ if ! flag_set no-postinst; then
         POSTINST_FILES="$(find "$POSTINST_DIR" -maxdepth 1 -type f | sort)"
         for file in $POSTINST_FILES; do
             info "> Processing $file"
-            "$file" "$MNT" "$FLAGS" || true
+            FIT="$FIT" "$file" "$MNT" "$FLAGS" || true
         done
     fi
 

--- a/image/install_update.sh
+++ b/image/install_update.sh
@@ -158,10 +158,6 @@ if ! flag_set no-postinst; then
     umount "$MNT/sys"
 fi
 
-info "Unmounting new rootfs"
-umount $MNT
-sync; sync
-
 info "Switching to new rootfs"
 fw_setenv mmcpart $PART
 fw_setenv upgrade_available 1
@@ -171,6 +167,10 @@ rm_fit
 led_success || true
 
 if ! flag_set no-reboot; then
+    info "Unmounting new rootfs"
+    umount $MNT
+    sync; sync
+
     info "Reboot system"
     mqtt_status REBOOT
     trap EXIT


### PR DESCRIPTION
Нужно для того, чтобы postinst-скрипты знали, из какого файла делалось обновление (например, чтобы сохранить файл в .wb-restore при factoryreset)