### PR TITLE
Feature/57336 discard bullseye to stretch

### DIFF
--- a/image/install_update.sh
+++ b/image/install_update.sh
@@ -115,13 +115,10 @@ if [ "$ACTUAL_DEB_RELEASE" = "bullseye" ] && [ "$upcoming_deb_release" = "stretc
         >&2 cat <<EOF
 ##############################################################################
 
-    UPGRADE FROM $ACTUAL_DEB_RELEASE TO $upcoming_deb_release REQUESTED
+    ROLLBACK FROM $ACTUAL_DEB_RELEASE TO $upcoming_deb_release REQUESTED
 
                     Due to major Debian release changes,
                 this operation is allowed only via FACTORYRESET.
-
-           This WILL destroy ALL YOUR DATA: configuration, scripts,
-                           files in home directory!
 
     Rename .fit file to "wbX_update_FACTORYRESET.fit" ->
     put renamed file to usb-drive ->

--- a/image/install_update.sh
+++ b/image/install_update.sh
@@ -88,11 +88,12 @@ flag_set "from-initramfs" && {
     [[ -e $ROOT_PART ]] && [[ -e $actual_rootfs ]] || {
         die "rootfs partition doesn't exist, looks like partitions table is broken. Give up."
     }
-    info "Temporarily mount actual rootfs $actual_rootfs to check wb-release"
-    mount -t ext4 $actual_rootfs $MNT 2>&1 >/dev/null || true
-    sync
-    ACTUAL_DEB_RELEASE="$(grep -o 'TARGET=\w*/\w*' "$MNT"/usr/lib/wb-release | sed 's/TARGET=wb[[:digit:]]\+\///')"
-    umount -f $actual_rootfs 2>&1 >/dev/null || true
+    info "Temporarily mount actual rootfs $actual_rootfs to check os-release"
+    mount -t ext4 $actual_rootfs $MNT 2>&1 >/dev/null && {
+        sync
+        ACTUAL_DEB_RELEASE="$(MNT="$MNT" bash -c 'source "$MNT/etc/os-release"; echo $VERSION_CODENAME')"
+        umount -f $actual_rootfs 2>&1 >/dev/null || true
+    } || true
 }
 
 # determine if new partition is unformatted
@@ -106,20 +107,37 @@ umount -f $ROOT_PART 2>&1 >/dev/null || true # just for sure
 info "Mounting $ROOT_PART at $MNT"
 mount -t ext4 "$ROOT_PART" "$MNT" 2>&1 >/dev/null|| die "Unable to mount root filesystem"
 
-[[ -z "$ACTUAL_DEB_RELEASE" ]] && ACTUAL_DEB_RELEASE="$(grep -o 'TARGET=\w*/\w*' /usr/lib/wb-release | sed 's/TARGET=wb[[:digit:]]\+\///')"
+[[ -z "$ACTUAL_DEB_RELEASE" ]] && ACTUAL_DEB_RELEASE="$(MNT="$MNT" bash -c 'source "$MNT/etc/os-release"; echo $VERSION_CODENAME')"
 upcoming_deb_release="$(fit_prop_string / release-target | sed 's/wb[[:digit:]]\+\///')"
 info "Debian: $ACTUAL_DEB_RELEASE -> $upcoming_deb_release"
 if [ "$ACTUAL_DEB_RELEASE" = "bullseye" ] && [ "$upcoming_deb_release" = "stretch" ]; then
     if ! flag_set factoryreset; then
-        errmsg="Upgrade from $ACTUAL_DEB_RELEASE to $upcoming_deb_release is possible only via factoryreset!"
+        >&2 cat <<EOF
+##############################################################################
+
+    UPGRADE FROM $ACTUAL_DEB_RELEASE TO $upcoming_deb_release REQUESTED
+
+                    Due to major Debian release changes,
+                this operation is allowed only via FACTORYRESET.
+
+           This WILL destroy ALL YOUR DATA: configuration, scripts,
+                           files in home directory!
+
+    Rename .fit file to "wbX_update_FACTORYRESET.fit" ->
+    put renamed file to usb-drive ->
+    ensure, there is only one .fit file on usb-drive ->
+    insert usb-drive to controller and reboot ->
+    follow further factoryreset instructions.
+
+##############################################################################
+EOF
         if flag_set from-initramfs; then
-            info "$errmsg"
             led_failure
             bash -c 'source /lib/libupdate.sh; buzzer_init; buzzer_on; sleep 1; buzzer_off'
             info "Rebooting..."
             reboot -f
         else
-            die "$errmsg"
+            die "Aborting..."
         fi
     fi
 fi

--- a/image/install_update.sh
+++ b/image/install_update.sh
@@ -107,7 +107,7 @@ umount -f $ROOT_PART 2>&1 >/dev/null || true # just for sure
 info "Mounting $ROOT_PART at $MNT"
 mount -t ext4 "$ROOT_PART" "$MNT" 2>&1 >/dev/null|| die "Unable to mount root filesystem"
 
-[[ -z "$ACTUAL_DEB_RELEASE" ]] && ACTUAL_DEB_RELEASE="$(MNT="$MNT" bash -c 'source "$MNT/etc/os-release"; echo $VERSION_CODENAME')"
+[[ -z "$ACTUAL_DEB_RELEASE" ]] && ACTUAL_DEB_RELEASE="$(bash -c 'source "/etc/os-release"; echo $VERSION_CODENAME')"
 upcoming_deb_release="$(fit_prop_string / release-target | sed 's/wb[[:digit:]]\+\///')"
 info "Debian: $ACTUAL_DEB_RELEASE -> $upcoming_deb_release"
 if [ "$ACTUAL_DEB_RELEASE" = "bullseye" ] && [ "$upcoming_deb_release" = "stretch" ]; then

--- a/image/install_update.sh
+++ b/image/install_update.sh
@@ -70,7 +70,7 @@ case "$PART" in
 		flag_set from-initramfs && {
 			info "Update is started from initramfs and unable to determine active rootfs partition, will overwrite rootfs0"
 			PART=2
-		PART_NOW=3
+			PART_NOW=3
 			PARTLABEL=rootfs0
 		} || {
 			die "Unable to determine second rootfs partition (current is $PART)"
@@ -111,7 +111,16 @@ upcoming_deb_release="$(fit_prop_string / release-target | sed 's/wb[[:digit:]]\
 info "Debian: $ACTUAL_DEB_RELEASE -> $upcoming_deb_release"
 if [ "$ACTUAL_DEB_RELEASE" = "bullseye" ] && [ "$upcoming_deb_release" = "stretch" ]; then
     if ! flag_set factoryreset; then
-        die "Upgrade from $ACTUAL_DEB_RELEASE to $upcoming_deb_release is possible only via factoryreset"
+        errmsg="Upgrade from $ACTUAL_DEB_RELEASE to $upcoming_deb_release is possible only via factoryreset!"
+        if flag_set from-initramfs; then
+            info "$errmsg"
+            led_failure
+            bash -c 'source /lib/libupdate.sh; buzzer_init; buzzer_on; sleep 1; buzzer_off'
+            info "Rebooting..."
+            reboot -f
+        else
+            die "$errmsg"
+        fi
     fi
 fi
 


### PR DESCRIPTION
Запрещаем переход с bullseye на stretch без factoryreset.

Проверял:

- инициаллизацию свежеспаянного wb собранным fit-ом
- обновление c флешки (bullseye->stretch без FR; bullseye->stretch с FR; stretch->stretch без FR)
- обновление из webui
![2023-03-01_16-20-29](https://user-images.githubusercontent.com/25829054/222167489-c1b96040-a927-4c81-b7a0-928ab2907464.png)
![2023-03-01_16-12-16](https://user-images.githubusercontent.com/25829054/222167497-5c6e4b60-3740-4e7c-8474-54967c0e01e6.png)
