### PR TITLE
devenv: fix build on ubuntu

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -1,27 +1,25 @@
 FROM debian:bullseye
-MAINTAINER ivan4th <ivan4th@gmail.com>
+LABEL org.opencontainers.image.authors="info@wirenboard.com"
+LABEL org.opencontainers.image.vendor="Wiren Board team"
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt update && apt install -y wget gnupg && \
-    wget -qO - https://github.com/wirenboard/keyring/raw/master/keyrings/contactless-keyring.gpg \
-       | apt-key add - && \
-    wget  https://github.com/wirenboard/keyring/raw/master/keyrings/contactless-keyring.gpg \
-       --output-document=/usr/share/keyrings/contactless-keyring.gpg && \
-    echo "deb [arch=amd64] http://deb.wirenboard.com/dev-tools stable main" > \
+RUN apt update && apt install -y curl wget gnupg && \
+    curl -fsSL https://github.com/wirenboard/keyring/raw/master/keyrings/contactless-keyring.gpg > \
+       /usr/share/keyrings/contactless-keyring.gpg && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/contactless-keyring.gpg] http://deb.wirenboard.com/dev-tools stable main" > \
        /etc/apt/sources.list.d/wirenboard-dev-tools.list && \
-    apt-get install -y --allow-unauthenticated gnupg1 curl ca-certificates apt-transport-https && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys AEE07869 && \
+    apt-get install -y --allow-unauthenticated gnupg1 ca-certificates apt-transport-https && \
     # TODO: add llvm dependencies to our own repository \
-    curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    echo "deb [arch=amd64] http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-15 main" > \
+    curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/apt.llvm.org.gpg && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/apt.llvm.org.gpg] http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-15 main" > \
        /etc/apt/sources.list.d/llvm-bullseye-15.list && \
     \
     # Low-priority testing repo for pinning pylint \
     echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list.d/testing.list && \
     echo 'Package: *\nPin: release a=testing\nPin-Priority: 70\n\n\
 Package: pylint python3-astroid python3-typing-extensions python3-dill\nPin: release a=testing\nPin-Priority: 900' > \
- /etc/apt/preferences.d/pylint-from-testing.pref && \
+       /etc/apt/preferences.d/pylint-from-testing.pref && \
     \
     apt update &&\
     apt install -y --force-yes git debootstrap proot build-essential pkg-config debhelper \


### PR DESCRIPTION
Steps to reproduce (Ubuntu):
```sh
$ make -C devenv
...
#0 16.91 Warning: apt-key is deprecated. Manage keyring files in trusted.gpg.d instead (see apt-key(8)).
#0 16.93 Executing: /tmp/apt-key-gpghome.NiDjwaCYtH/gpg.1.sh --keyserver keyserver.ubuntu.com --recv-keys AEE07869
#0 16.96 gpg: keyserver receive failed: Server indicated a failure
...
make: *** [Makefile:4: all] Error 1
```
At the same time there is no problem with `gpg --keyserver keyserver.ubuntu.com --recv-keys AEE07869` on the host.
But we can skip it, since `contactless-keyring` already includes `AEE07869` key:
```sh
curl -L https://github.com/wirenboard/keyring/raw/master/keyrings/contactless-keyring.gpg | gpg --show-keys
pub   rsa2048 2014-04-23 [SC]
      B750A0D6805540824F039964E4B0949FAEE07869
uid                      Evgeny Boger <boger@contactless.ru>
sub   rsa2048 2014-04-23 [E]

pub   rsa2048 2016-12-18 [SC]
      77326BACD64B392F1014B37FBD4CEEDBAA549AA8
uid                      wirenboard <robot@contactless.ru>
sub   rsa2048 2016-12-18 [E]
```

What about keyring storage:
> Although adding keys directly to /etc/apt/trusted.gpg.d/ is suggested by apt-key deprecation message, as per [Debian Wiki](https://wiki.debian.org/DebianRepository/UseThirdParty) GPG keys for third party repositories should be added to /usr/share/keyrings and referenced with the signed-by option in the source.list.d entry.