### PR TITLE
devenv: make it work when called from Docker container

### DIFF
--- a/devenv/entrypoint.sh
+++ b/devenv/entrypoint.sh
@@ -102,9 +102,6 @@ if ! getent passwd "$DEV_USER" >& /dev/null; then
     adduser --uid "$DEV_UID" --gecos "" --gid "$DEV_GID" --disabled-password --no-create-home "$DEV_USER" >& /dev/null
 fi
 
-# fix package installation issues
-chown -R "$DEV_USER.$DEV_GROUP" /usr/local/go
-
 # setup Go environment (for non-login shell cases)
 . /etc/profile.d/wbdev_profile.sh
 

--- a/devenv/wbdev_second_half.sh
+++ b/devenv/wbdev_second_half.sh
@@ -19,6 +19,27 @@ else
 fi
 
 PREFIX="$VM_HOME/wbdev/go/src/github.com/contactless"
+VOLUMES=""
+
+if [[ -n "$DEV_VOLUME" ]]; then
+    DEV_VOLUME_PREFIX="${DEV_VOLUME##*:}"
+
+    case "$PWD" in
+    "$DEV_VOLUME_PREFIX"*)
+        ;;
+    *)
+        echo "DEV_VOLUME is set; PWD must start with $DEV_VOLUME_PREFIX"
+        exit 1
+        ;;
+    esac
+
+    VOLUMES="$VOLUMES -v $DEV_VOLUME"
+    DEV_DIR="${PWD}"
+elif [[ -z "$DEV_DIR" ]]; then
+    DEV_DIR="$PREFIX/${PWD##*/}"
+    VOLUMES="$VOLUMES -v $HOME:$VM_HOME -v ${PWD%/*}:$PREFIX"
+fi
+
 
 ENV_CMDLINE=""
 for var in $(env | grep -o "WBDEV_[^=]*"); do
@@ -28,13 +49,12 @@ done
 docker run $DOCKER_TTY_OPTS --privileged --rm \
        -e DEV_UID=$UID \
        -e DEV_USER=$USER \
-       -e DEV_DIR="$PREFIX/${PWD##*/}" \
+       -e DEV_DIR="$DEV_DIR" \
        -e DEV_TERM="$TERM" \
        $ENV_CMDLINE \
        -e DEB_BUILD_OPTIONS \
        -e DEB_BUILD_PROFILES \
-       -v $HOME:$VM_HOME \
-       -v ${PWD%/*}:$PREFIX \
+       $VOLUMES \
        $ssh_opts \
        -h wbdevenv \
        $WBDEV_IMAGE \

--- a/devenv/wbdev_second_half.sh
+++ b/devenv/wbdev_second_half.sh
@@ -21,7 +21,7 @@ fi
 PREFIX="$VM_HOME/wbdev/go/src/github.com/contactless"
 
 ENV_CMDLINE=""
-for var in `env | grep -oP "WBDEV_[^=]*"`; do
+for var in $(env | grep -o "WBDEV_[^=]*"); do
     ENV_CMDLINE="$ENV_CMDLINE -e $var"
 done
 

--- a/wbdev
+++ b/wbdev
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 WBDEV_IMAGE=${WBDEV_IMAGE:-"contactless/devenv:latest"}
-FNAME=`mktemp /tmp/wbdev.sh.XXXXX`
+FNAME=`mktemp /tmp/wbdev.sh.XXXXXX`
 docker run --rm --entrypoint cat ${WBDEV_IMAGE} /wbdev_second_half.sh > ${FNAME}
 chmod a+x ${FNAME}
 cleanup() {


### PR DESCRIPTION
Попробовал использовать wbdev в связке с контейнером с jenkins agent (на базе Alpine), столкнулся с небольшими проблемами:

 - некоторые команды испортились, потому что alpine под капотом имеет busybox с ограниченным числом флагов;
 - испортился bind mount при запуске wbdev, поскольку при запуске из контейнера путь в `-v` всё равно надо писать как из хостовой системы.

Для второго я добавил переменную окружения `DEV_VOLUME`, в которую надо передать пару `volume:/path/to/bind`. Этот volume подключится к wbdev вместо обычных `HOME` и `PWD` (естественно, нужно находиться в этот момент в директории, дочерней к `/path/to/mount`).

Заодно убрал `chown` Go-шных библиотек из `entrypoint.sh`, всё равно никому он сейчас не нужен, а времени при запуске отъедает очень много даже с nvme.