### PR TITLE
umount rootfs on failure from webui

### DIFF
--- a/image/install_update.sh
+++ b/image/install_update.sh
@@ -134,6 +134,7 @@ EOF
             info "Rebooting..."
             reboot -f
         else
+            umount -f $ROOT_PART 2>&1 >/dev/null || true
             die "Aborting..."
         fi
     fi


### PR DESCRIPTION
Если попытаться обновить запрещенным (bullseye -> stretch) fit-ом контроллер несколько раз подряд, то начиная со второго раза, install_update падает при попытке очистки mountpoint'a, жалуясь на то, что device is busy.

Решение - отмонтируем rootfs