### PR TITLE
ci: use rootfs-builder tagged node to build rootfs-related pipelines

### DIFF
--- a/ci/pipelines/buildImage.groovy
+++ b/ci/pipelines/buildImage.groovy
@@ -6,7 +6,7 @@
 
 pipeline {
     agent {
-        label "devenv"
+        label "rootfs-builder"
     }
     parameters {
         choice(name: 'BOARD', choices: wb.boards, description: 'Board version to build image for')

--- a/ci/pipelines/checkStaging.groovy
+++ b/ci/pipelines/checkStaging.groovy
@@ -13,7 +13,7 @@ def changesDetected = false
 
 pipeline {
     agent {
-        label "devenv"
+        label "rootfs-builder"
     }
     parameters {
         string(name: 'DEBIAN_RELEASE', defaultValue: 'bullseye', description: 'debian release')

--- a/ci/pipelines/publishImage.groovy
+++ b/ci/pipelines/publishImage.groovy
@@ -7,7 +7,7 @@
 
 pipeline {
     agent {
-        label "devenv"
+        label "rootfs-builder"
     }
     parameters {
         string(name: 'IMAGE_BUILDNUMBER', defaultValue: '', description: 'from pipelines/build-image')

--- a/ci/pipelines/releaseImages.groovy
+++ b/ci/pipelines/releaseImages.groovy
@@ -10,7 +10,7 @@ def imagesJobs = []
 
 pipeline {
     agent {
-        label "devenv"
+        label "rootfs-builder"
     }
     parameters {
         string(name: 'DEBIAN_RELEASE', defaultValue: 'stretch', description: 'Debian release')


### PR DESCRIPTION
Я добавил тэг `rootfs-builder` к старой сборочной ноде и хочу, чтобы эти пайплайны пока что собирались только там (через alpine сходу не взлетело).

Для сборки rootfs недостаточно одного devenv, она ещё хочет модуль ядра binfmt_misc для запуска qemu (и пытается добавить его руками, почему-то на старой сборочной машине это работает из докера).

Когда починим сборку на alpine, просто добавим тэг `rootfs-builder` к новому сборщику и PR не понадобится.

Этот PR позволяет сейчас использовать новый сборщик для всех остальных пайплайнов.