### PR TITLE
devenv: define USER and UID if not defined (required by aptly builder)

### DIFF
--- a/devenv/wbdev_second_half.sh
+++ b/devenv/wbdev_second_half.sh
@@ -10,6 +10,13 @@ if [ -n "$SSH_AUTH_SOCK" ]; then
     ssh_opts="-e SSH_AUTH_SOCK=/ssh-agent -v $SSH_AUTH_SOCK:/ssh-agent"
 fi
 
+if [[ -z "$UID" ]]; then
+    UID="$(id -u)"
+fi
+
+if [[ -z "$USER" ]]; then
+    USER="$(id -n -u)"
+fi
 
 if [[ $OSTYPE == darwin* ]]
 then


### PR DESCRIPTION
В новом билдере aptly не объявляются переменные USER и UID по умолчанию, этот патч их доопределяет при необходимости