### PR TITLE
checkStaging: use new aptly-builder node

### DIFF
--- a/ci/pipelines/buildImage.groovy
+++ b/ci/pipelines/buildImage.groovy
@@ -28,7 +28,9 @@ pipeline {
     stages {
         stage('Checkout') {
             steps {
-                git branch: "$WIRENBOARD_BRANCH", url: 'git@github.com:wirenboard/wirenboard'
+                git branch: "$WIRENBOARD_BRANCH",
+                    url: 'git@github.com:wirenboard/wirenboard',
+                    credentialsId: 'jenkins-github-public-ssh'
             }
         }
         stage('Get u-boot and zImage') {


### PR DESCRIPTION
  * wbci make-ref call compatible with 2.0
  * disable concurrent builds
  * remove unused wirenboard checkout
  
Этот пайплайн используется для проверки содержимого staging после пуша в master любого пакета. Он проверяет, что образы прошивок собираются для staging, и в случае успеха передвигают на него снапшот-указатель `unstable.latest`, который можно использовать в releases.yaml для `testing`