### PR TITLE
Keep WBDEV_TARGET_REPO_RELEASE

### DIFF
--- a/devenv/entrypoint.sh
+++ b/devenv/entrypoint.sh
@@ -67,7 +67,6 @@ bullseye-armhf|current-armhf)
     WBDEV_TARGET_BOARD="wb6"
     WBDEV_TARGET_ARCH="armhf"
     WBDEV_TARGET_RELEASE="bullseye"
-    WBDEV_TARGET_REPO_RELEASE="testing"
     ;;
 bullseye-host|bullseye-amd64|current-amd64)
     WBDEV_TARGET_BOARD="host"


### PR DESCRIPTION
Do not override WBDEV_TARGET_REPO_RELEASE if bullseye-armhf or current-armhf WBDEV_TARGET is set