### PR TITLE
devenv: add fpm and cpio to build initramfs and bootlets

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -32,7 +32,7 @@ Package: pylint python3-astroid python3-typing-extensions python3-dill\nPin: rel
        python3-smbus python3-setuptools liblog4cpp5-dev libpng-dev bison flex kmod dh-python \
        clang-format \
     # for image building \
-    fdisk u-boot-tools fit-aligner \
+    fdisk u-boot-tools fit-aligner cpio \
     # legacy requirement for kernel building \
     rsync  \
     # legacy requirement for go-required packages \
@@ -40,7 +40,9 @@ Package: pylint python3-astroid python3-typing-extensions python3-dill\nPin: rel
     # for Jenkins python checks \
     pylint black python3-isort \
     # for Jenkins deployments \
-    python3-wbci s3cmd
+    python3-wbci s3cmd \
+    # to install fpm later for simple package building \
+    ruby-rubygems && gem install fpm
 
 
 # FIXME: we should not install anything with --force-yes


### PR DESCRIPTION
Эти утилиты нужны, чтобы собирать архив с initramfs для ядра, и чтобы получить в итоге пакет без сложной deb-машинерии (так правда было быстрее).

Ссылка на этот PR останется в коде в wb-initramfs, чтобы удалить оттуда ненужный кусочек потом