### PR TITLE
devenv: install known build deps both in docker and schroot

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -47,7 +47,7 @@ Package: pylint python3-astroid python3-typing-extensions python3-dill\nPin: rel
 # install common build-dependencies
 # TODO: remove it after full migration to sbuild
 COPY common-deps.sh /root/
-RUN bash -e -c 'source /root/common-deps.sh; apt-get update && apt-get install -y --force-yes ${COMMON_DEPS[@]}'
+RUN bash -e -c 'source /root/common-deps.sh; apt-get update && apt-get install -y "${KNOWN_BUILD_DEPS[@]}"'
 
 
 # FIXME: we should not install anything with --force-yes

--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -44,6 +44,11 @@ Package: pylint python3-astroid python3-typing-extensions python3-dill\nPin: rel
     # to install fpm later for simple package building \
     ruby-rubygems && gem install fpm
 
+# install common build-dependencies
+# TODO: remove it after full migration to sbuild
+COPY common-deps.sh /root/
+RUN bash -e -c 'source /root/common-deps.sh; apt-get update && apt-get install -y --force-yes ${COMMON_DEPS[@]}'
+
 
 # FIXME: we should not install anything with --force-yes
 

--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -2,22 +2,7 @@
 set -u -e
 cd /root
 
-KNOWN_BUILD_DEPS=(
-    # test-suite-ng
-    dh-python
-    python3-all
-    python3-libgpiod
-    python3-numpy
-    python3-pil
-    python3-qrcode
-    python3-pymysql
-    python3-pytest
-    python3-semantic-version
-    python3-testinfra
-    python3-tqdm
-    python3-usb
-    python3-wb-mcu-fw-updater
-)
+source /root/common-deps.sh
 
 do_build() {
 	export RELEASE=$1 ARCH=$2 BOARD=$3 PLATFORM=$4

--- a/devenv/common-deps.sh
+++ b/devenv/common-deps.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# This file lists common deps for Wiren Board packages.
+# It is included by build.sh and Dockerfile.
+# It must export KNOWN_BUILD_DEPS array.
+
+export KNOWN_BUILD_DEPS=(
+    # test-suite-ng
+    dh-python
+    python3-all
+    python3-libgpiod
+    python3-numpy
+    python3-pil
+    python3-qrcode
+    python3-pymysql
+    python3-pytest
+    python3-semantic-version
+    python3-testinfra
+    python3-tqdm
+    python3-usb
+    python3-wb-mcu-fw-updater
+)
+


### PR DESCRIPTION
Продолжение #168, оказалось недостаточно установить только в sbuild