### PR TITLE
devenv: add arm64 architecture

### DIFF
--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -27,8 +27,9 @@ do_build_sbuild_env() {
 		REPO="http://archive.debian.org/debian"
 	fi
 
-	sbuild-createchroot --include="crossbuild-essential-armhf crossbuild-essential-armel build-essential libarchive-zip-perl libtimedate-perl libglib2.0-0 pkg-config libfile-stripnondeterminism-perl gettext intltool-debian po-debconf dh-autoreconf dh-strip-nondeterminism debhelper libgtest-dev cmake git ca-certificates"  ${RELEASE} ${ROOTFS} ${REPO}
+	sbuild-createchroot --include="crossbuild-essential-arm64 crossbuild-essential-armhf crossbuild-essential-armel build-essential libarchive-zip-perl libtimedate-perl libglib2.0-0 pkg-config libfile-stripnondeterminism-perl gettext intltool-debian po-debconf dh-autoreconf dh-strip-nondeterminism debhelper libgtest-dev cmake git ca-certificates"  ${RELEASE} ${ROOTFS} ${REPO}
 
+	schroot -c ${CHROOT_NAME} --directory=/ -- dpkg --add-architecture arm64
 	schroot -c ${CHROOT_NAME} --directory=/ -- dpkg --add-architecture armhf
 	schroot -c ${CHROOT_NAME} --directory=/ -- dpkg --add-architecture armel
 	schroot -c ${CHROOT_NAME} --directory=/ -- apt-get update


### PR DESCRIPTION
Попробовал собрать libwbmqtt1-4, получилось. Остальные пакеты могут потребовать зависимости от libwbmqtt1-4, так что сначала надо будет сделать репозиторий (это следующим PR).

Поскольку репозитория в deb.wirenboard.com для arm64 ещё нет, сделал так, чтобы его наличие было не обязательным (это не должно повлиять на сборки позже, т.к. пакеты не соберутся из-за отсутствия зависимостей)