### PR TITLE
devenv: enable ccache in schroot

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -30,7 +30,7 @@ Package: pylint python3-astroid python3-typing-extensions python3-dill\nPin: rel
        valgrind libgtest-dev google-mock cmake config-package-dev libssl-dev bc lzip lzop \
        python3-netaddr python3-pyparsing liblircclient-dev libusb-dev libusb-1.0-0-dev jq \
        python3-smbus python3-setuptools liblog4cpp5-dev libpng-dev bison flex kmod dh-python \
-       clang-format lintian \
+       clang-format lintian ccache \
     # for image building \
     fdisk u-boot-tools fit-aligner cpio \
     # legacy requirement for kernel building \
@@ -87,6 +87,11 @@ COPY projects.list /
 COPY chr /usr/local/bin/
 COPY debootstrap-functions.diff /usr/share/debootstrap/
 RUN chmod +x /root/*.sh /usr/local/bin/chr
+
+RUN mkdir -p /var/cache/ccache && chmod 777 /var/cache/ccache
+COPY schroot/fstab /etc/schroot/sbuild/fstab
+COPY schroot/copyfiles /etc/schroot/sbuild/copyfiles
+COPY schroot/ccache-setup /usr/local/bin/ccache-setup
 
 # patch a bug in debootstrap/functions, preventing schroot from working inside Docker 
 # see https://bugs.launchpad.net/ubuntu/+source/debootstrap/+bug/1948713

--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -27,7 +27,8 @@ do_build_sbuild_env() {
 		REPO="http://archive.debian.org/debian"
 	fi
 
-	sbuild-createchroot --include="crossbuild-essential-arm64 crossbuild-essential-armhf crossbuild-essential-armel build-essential libarchive-zip-perl libtimedate-perl libglib2.0-0 pkg-config libfile-stripnondeterminism-perl gettext intltool-debian po-debconf dh-autoreconf dh-strip-nondeterminism debhelper libgtest-dev cmake git ca-certificates"  ${RELEASE} ${ROOTFS} ${REPO}
+	sbuild-createchroot --include="crossbuild-essential-arm64 crossbuild-essential-armhf crossbuild-essential-armel build-essential libarchive-zip-perl libtimedate-perl libglib2.0-0 pkg-config libfile-stripnondeterminism-perl gettext intltool-debian po-debconf dh-autoreconf dh-strip-nondeterminism debhelper libgtest-dev cmake git ca-certificates ccache"  ${RELEASE} ${ROOTFS} ${REPO}
+    SCHROOT_CONF="$(find /etc/schroot/chroot.d/ -name "${CHROOT_NAME}*" -type f | head -n1)"
 
 	schroot -c ${CHROOT_NAME} --directory=/ -- dpkg --add-architecture arm64
 	schroot -c ${CHROOT_NAME} --directory=/ -- dpkg --add-architecture armhf
@@ -105,17 +106,20 @@ EOF
 	#output everyting on screen instead of file
 	echo "\$nolog = 1;" >> /etc/sbuild/sbuild.conf
 
+    # enable ccache wrapper
+    echo "command-prefix=/usr/local/bin/ccache-setup" >> "${SCHROOT_CONF}"
+
 	# set correct symlink to /dev/ptmx
 	rm -f ${ROOTFS}/dev/ptmx
 	ln -s /dev/pts/ptmx ${ROOTFS}/dev/ptmx
 }
 
-do_build stretch armel 58 wb2
-do_build stretch armhf 6x wb6
+#do_build stretch armel 58 wb2
+#do_build stretch armhf 6x wb6
 
-do_build bullseye armhf 6x wb6
+#do_build bullseye armhf 6x wb6
 
-do_build_sbuild_env stretch 
+#do_build_sbuild_env stretch 
 do_build_sbuild_env bullseye "${KNOWN_BUILD_DEPS[@]}"
 
 # TBD: run chroot:

--- a/devenv/entrypoint.sh
+++ b/devenv/entrypoint.sh
@@ -92,7 +92,9 @@ rm -f /.devdir $ROOTFS/.devdir
 if [ -n "$DEV_DIR" ]; then
     if [ -n "$shell_cmd" ]; then
         echo "$DEV_DIR" >/.devdir
-        echo "$DEV_DIR" >$ROOTFS/.devdir
+        if [[ -d "$ROOTFS" ]]; then
+            echo "$DEV_DIR" >"$ROOTFS/.devdir"
+        fi
     elif ! cd "$DEV_DIR"; then
         echo "WARNING: can't chdir to $DEV_DIR"
     fi

--- a/devenv/schroot/ccache-setup
+++ b/devenv/schroot/ccache-setup
@@ -1,0 +1,13 @@
+#!/bin/sh
+export CCACHE_DIR=/var/cache/ccache
+
+# skip ccache if the CCACHE_DIR does not exist
+if [ ! -d "$CCACHE_DIR" ]; then
+    exec "$@"
+fi
+
+export CCACHE_UMASK=002
+export CCACHE_COMPRESS=1
+unset CCACHE_HARDLINK
+export PATH="/usr/lib/ccache:$PATH"
+exec "$@"

--- a/devenv/schroot/copyfiles
+++ b/devenv/schroot/copyfiles
@@ -1,0 +1,2 @@
+/etc/resolv.conf
+/usr/local/bin/ccache-setup

--- a/devenv/schroot/fstab
+++ b/devenv/schroot/fstab
@@ -1,0 +1,13 @@
+# fstab: static file system information for chroots.
+# Note that the mount point will be prefixed by the chroot path
+# (CHROOT_PATH)
+#
+# <file system> <mount point>   <type>  <options>       <dump>  <pass>
+/proc           /proc           none    rw,bind         0       0
+/sys            /sys            none    rw,bind         0       0
+/dev/pts        /dev/pts        none    rw,bind         0       0
+tmpfs           /dev/shm        tmpfs   defaults        0       0
+# Mount a large scratch space for the build, so we don't use up
+# space on an LVM snapshot of the chroot itself.
+/var/lib/sbuild/build  /build   none    rw,bind         0       0
+/var/cache/ccache      /var/cache/ccache  none    rw,bind         0       0

--- a/devenv/wbdev_second_half.sh
+++ b/devenv/wbdev_second_half.sh
@@ -49,6 +49,9 @@ elif [[ -z "$DEV_DIR" ]]; then
     VOLUMES="$VOLUMES -v $HOME:$VM_HOME -v ${PWD%/*}:$PREFIX"
 fi
 
+if [[ -n "$DEV_CCACHE_VOLUME" ]]; then
+    VOLUMES="$VOLUMES -v $DEV_CCACHE_VOLUME:/var/cache/ccache"
+fi
 
 ENV_CMDLINE=""
 for var in $(env | grep -o "WBDEV_[^=]*"); do


### PR DESCRIPTION
External Docker volume is forwarded via DEV_CCACHE_VOLUME env variable in wbdev launcher.

Позволяет ускорить сборку пакетов где-то на 20-25% (на примере wb-mqtt-serial и linux).