### PR TITLE
wbdev: fix shebang

### DIFF
--- a/wbdev
+++ b/wbdev
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 WBDEV_IMAGE=${WBDEV_IMAGE:-"contactless/devenv:latest"}
 FNAME=`mktemp /tmp/wbdev.sh.XXXXXX`
 docker run --rm --entrypoint cat ${WBDEV_IMAGE} /wbdev_second_half.sh > ${FNAME}


### PR DESCRIPTION
Не во всех linux дистрибутивах bash живет в `/bin`. А у пользователя желающего собрать [кастомный FIT](https://github.com/wirenboard/custom-fit-image-template) может быть какой угодно дистрибутив.