### PR TITLE
wbdev_second_half.sh: fix shebang

### DIFF
--- a/devenv/wbdev_second_half.sh
+++ b/devenv/wbdev_second_half.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This file will be executed on host to run docker container
 
 DEB_BUILD_PROFILES=${DEB_BUILD_PROFILES:-"cross"}


### PR DESCRIPTION
В продолжение https://github.com/wirenboard/wirenboard/pull/177, wbdev_second_half.sh тоже на хосте запускается, не в контейнере.