### PR TITLE
devenv: generate compile_commands.json

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -30,7 +30,7 @@ Package: pylint python3-astroid python3-typing-extensions python3-dill\nPin: rel
        valgrind libgtest-dev google-mock cmake config-package-dev libssl-dev bc lzip lzop \
        python3-netaddr python3-pyparsing liblircclient-dev libusb-dev libusb-1.0-0-dev jq \
        python3-smbus python3-setuptools liblog4cpp5-dev libpng-dev bison flex kmod dh-python \
-       clang-format lintian ccache \
+       clang-format clang-tidy lintian ccache \
     # for image building \
     fdisk u-boot-tools fit-aligner cpio \
     # legacy requirement for kernel building \
@@ -42,7 +42,9 @@ Package: pylint python3-astroid python3-typing-extensions python3-dill\nPin: rel
     # for Jenkins deployments \
     python3-wbci s3cmd \
     # to install fpm later for simple package building \
-    ruby-rubygems && gem install fpm
+    ruby-rubygems && gem install fpm && \
+    # for clang-tidy checks
+    pip3 install compiledb
 
 # install common build-dependencies
 # TODO: remove it after full migration to sbuild

--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -76,7 +76,7 @@ EOF
 
 	#install multi-arch common build dependencies 
 	schroot -c ${CHROOT_NAME} --directory=/ -- apt-get -y install libssl-dev:armhf linux-libc-dev:armhf libc6-dev:armhf libc-ares2:armhf \
-		libssl-dev:armel linux-libc-dev:armel libc6-dev:armel libc-ares2:armel golang-go node-rimraf python3-jinja2 \
+		libssl-dev:armel linux-libc-dev:armel libc6-dev:armel libc-ares2:armel golang-go node-rimraf python3-jinja2 j2cli \
 		"${ADD_PACKAGES[@]}"
 
 	#virtualization support packages

--- a/devenv/entrypoint.sh
+++ b/devenv/entrypoint.sh
@@ -348,7 +348,13 @@ case "$cmd" in
         print_target_info
         chr apt-get update
         chr mk-build-deps -ir -t "apt-get --force-yes -y"
-        chu make -Bnwk | compiledb -o compile_commands.json
+        if [ -f CMakeLists.txt ]; then
+            mkdir -p build
+            cd build
+            chu cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+        elif [ -f Makefile ]; then
+            chu make -Bnwk | compiledb -o compile_commands.json
+        fi
         $shell_cmd "$@"
         ;;
     cdeb)

--- a/devenv/entrypoint.sh
+++ b/devenv/entrypoint.sh
@@ -269,7 +269,8 @@ sbuild_buildpackage() {
 
     if has_arch_any; then
         echo "Build packages for binary architectures"
-        sbuild --no-arch-all --arch-any --host="$ARCH" "${SBUILD_ARGS[@]}"
+        sbuild --no-arch-all --arch-any --host="$ARCH" "${SBUILD_ARGS[@]}" | tee sbuild.log
+        grep "gcc\|g++" sbuild.log | compiledb -o compile_commands.json
     else
         echo "No binary architecture packages in this source"
     fi

--- a/devenv/entrypoint.sh
+++ b/devenv/entrypoint.sh
@@ -269,8 +269,7 @@ sbuild_buildpackage() {
 
     if has_arch_any; then
         echo "Build packages for binary architectures"
-        sbuild --no-arch-all --arch-any --host="$ARCH" "${SBUILD_ARGS[@]}" | tee sbuild.log
-        grep "gcc\|g++" sbuild.log | compiledb -o compile_commands.json
+        sbuild --no-arch-all --arch-any --host="$ARCH" "${SBUILD_ARGS[@]}"
     else
         echo "No binary architecture packages in this source"
     fi
@@ -344,6 +343,13 @@ case "$cmd" in
             chr mk-build-deps -ir -t "apt-get --force-yes -y"
         fi
         chu make "$@"
+        ;;
+    compiledb)
+        print_target_info
+        chr apt-get update
+        chr mk-build-deps -ir -t "apt-get --force-yes -y"
+        chu make -Bnwk | compiledb -o compile_commands.json
+        $shell_cmd "$@"
         ;;
     cdeb)
         print_target_info

--- a/devenv/entrypoint.sh
+++ b/devenv/entrypoint.sh
@@ -350,8 +350,10 @@ case "$cmd" in
         chr mk-build-deps -ir -t "apt-get --force-yes -y"
         if [ -f CMakeLists.txt ]; then
             mkdir -p build
-            cd build
+            pushd build
             chu cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
+            popd
+            mv build/compile_commands.json compile_commands.json
         elif [ -f Makefile ]; then
             chu make -Bnwk | compiledb -o compile_commands.json
         fi


### PR DESCRIPTION
Usage example:
`wbdev compiledb ./clang-tidy-subdirs.sh src test`