### PR TITLE
publishImage: clean up after build

### DIFF
--- a/ci/pipelines/publishImage.groovy
+++ b/ci/pipelines/publishImage.groovy
@@ -119,4 +119,12 @@ pipeline {
             }
         }
     }
+    post {
+        always {
+            echo "Cleaning up"
+            cleanWs cleanWhenNotBuilt: false,
+                    deleteDirs: true,
+                    notFailBuild: true
+        }
+    }
 }


### PR DESCRIPTION
Сейчас все загруженные в S3 образы остаются в workspace этой джобы. надо подчищать, тогда не будет неконтролируемо расти потребление места