### PR TITLE
image: Wiren Board 8 images support

### DIFF
--- a/boards/include/soc_imx23.sh
+++ b/boards/include/soc_imx23.sh
@@ -2,5 +2,6 @@ export ARCH=armel
 export KERNEL_FLAVOUR=wb2
 export IMAGE_TYPE=mx23
 export U_BOOT=UNSUPPORTED
+export BOARD_SUPPORTS_IMG=y
 
 BOARD_PACKAGES+=( wb-adc-tools-mxs )

--- a/boards/include/soc_imx28.sh
+++ b/boards/include/soc_imx28.sh
@@ -3,5 +3,6 @@ export KERNEL_FLAVOUR=wb2
 export IMAGE_TYPE=mx28
 export U_BOOT=contrib/u-boot/u-boot.wb5.sd
 export REPO_PLATFORM=wb5
+export BOARD_SUPPORTS_IMG=y
 
 BOARD_PACKAGES+=( wb-adc-tools-mxs )

--- a/boards/include/soc_imx6ul.sh
+++ b/boards/include/soc_imx6ul.sh
@@ -5,3 +5,4 @@ export U_BOOT=contrib/u-boot/u-boot.wb6.imx
 export U_BOOT_ROOTFS=usr/lib/u-boot/mx6ul_wirenboard6/u-boot-with-spl.imx
 export REPO_PLATFORM=wb6
 export FIT_IMAGE_DTB=imx6ul-wirenboard6x-init.dtb
+export BOARD_SUPPORTS_IMG=y

--- a/boards/include/soc_imx6ul.sh
+++ b/boards/include/soc_imx6ul.sh
@@ -6,3 +6,5 @@ export U_BOOT_ROOTFS=usr/lib/u-boot/mx6ul_wirenboard6/u-boot-with-spl.imx
 export REPO_PLATFORM=wb6
 export FIT_IMAGE_DTB=imx6ul-wirenboard6x-init.dtb
 export BOARD_SUPPORTS_IMG=y
+export BOARD_BOOTLET_ON_S3=y
+export BOARD_BOOTLET_IN_ROOTFS=y

--- a/boards/include/soc_sun50i_h616.sh
+++ b/boards/include/soc_sun50i_h616.sh
@@ -4,3 +4,4 @@ export IMAGE_TYPE=sun50i_h616
 export U_BOOT=contrib/u-boot/u-boot.wb8.bin
 export U_BOOT_ROOTFS=usr/lib/u-boot/sun50i_wirenboard8/u-boot-sunxi-with-spl.bin
 export REPO_PLATFORM=wb8
+export BOARD_SUPPORTS_IMG=n

--- a/boards/include/soc_sun50i_h616.sh
+++ b/boards/include/soc_sun50i_h616.sh
@@ -4,4 +4,4 @@ export IMAGE_TYPE=sun50i_h616
 export U_BOOT=contrib/u-boot/u-boot.wb8.bin
 export U_BOOT_ROOTFS=usr/lib/u-boot/sun50i_wirenboard8/u-boot-sunxi-with-spl.bin
 export REPO_PLATFORM=wb8
-export BOARD_SUPPORTS_IMG=n
+export BOARD_BOOTLET_IN_ROOTFS=y

--- a/boards/include/soc_sun8i_r40.sh
+++ b/boards/include/soc_sun8i_r40.sh
@@ -5,3 +5,5 @@ export U_BOOT=contrib/u-boot/u-boot.wb7.bin
 export U_BOOT_ROOTFS=usr/lib/u-boot/sun8i_wirenboard7/u-boot-sunxi-with-spl.bin
 export REPO_PLATFORM=wb7
 export BOARD_SUPPORTS_IMG=y
+export BOARD_BOOTLET_ON_S3=y
+export BOARD_BOOTLET_IN_ROOTFS=y

--- a/boards/include/soc_sun8i_r40.sh
+++ b/boards/include/soc_sun8i_r40.sh
@@ -4,3 +4,4 @@ export IMAGE_TYPE=sun8i_r40
 export U_BOOT=contrib/u-boot/u-boot.wb7.bin
 export U_BOOT_ROOTFS=usr/lib/u-boot/sun8i_wirenboard7/u-boot-sunxi-with-spl.bin
 export REPO_PLATFORM=wb7
+export BOARD_SUPPORTS_IMG=y

--- a/image/create_image.sh
+++ b/image/create_image.sh
@@ -59,6 +59,11 @@ write_uboot_sun8i_r40() {
 
 eval "PART_START=\${PART_START_${SOC_TYPE}}"
 
+if [ -z "$PART_START" ]; then
+    echo "Unsupported soc type for *.img: $SOC_TYPE"
+    exit 1
+fi
+
 truncate -s ${IMGSIZE}M $IMGFILE
 
 # Generates single partition definition line for sfdisk.

--- a/image/create_images.sh
+++ b/image/create_images.sh
@@ -79,7 +79,7 @@ mkdir -p ${OUT_DIR}
 IMG_NAME="${OUT_DIR}/${FULL_VERSION}_emmc_wb${BOARD}.img"
 WEBUPD_NAME="${OUT_DIR}/${FULL_VERSION}_wb${BOARD}.fit"
 
-if  [ -n "$MAKE_IMG" ]; then
+if  [ -n "$MAKE_IMG" ] && [ "$BOARD_SUPPORTS_IMG" == "y" ]; then
     echo "Create IMG"
     rm -f ${IMG_NAME}
 

--- a/image/create_update.sh
+++ b/image/create_update.sh
@@ -74,9 +74,6 @@ elif [[ -e "$ROOTFS" ]]; then
 	ROOTFS_TARBALL=$ROOTFS
 fi
 
-COMPATIBLE=`dtb_get_compatible < "$TARGET_DTB"`
-[[ -n "$COMPATIBLE" ]] || die "Unable to get 'compatible' DTB param"
-
 VERSION=`cat "$ROOTFS/etc/wb-fw-version"` || die "Unable to get firmware version"
 source $ROOTFS/usr/lib/wb-release || die "Unable to get release information"
 
@@ -114,6 +111,16 @@ if [[ -e "$ROOTFS_BOOT_DTB_PATH" ]]; then
 else
     echo "No bootlet DTB in rootfs, using default one"
     BOOT_DTB="$DEFAULT_BOOT_DTB"
+fi
+
+if [[ -e "$TARGET_DTB" ]]; then
+    echo "Using compatible from target DTB ($TARGET_DTB)"
+    COMPATIBLE=$(dtb_get_compatible < "$TARGET_DTB")
+    [[ -n "$COMPATIBLE" ]] || die "Unable to get 'compatible' DTB param"
+else
+    echo "Using compatible from boot DTB ($BOOT_DTB)"
+    COMPATIBLE=$(dtb_get_compatible < "$BOOT_DTB")
+    [[ -n "$COMPATIBLE" ]] || die "Unable to get 'compatible' DTB param"
 fi
 
 ITS=$TMPDIR/update.its

--- a/image/create_update.sh
+++ b/image/create_update.sh
@@ -95,7 +95,19 @@ else
     FIRMWARE_COMPATIBLE="unknown"
 fi
 
-ROOTFS_BOOTLET_ZIMAGE_PATH="$ROOTFS/var/lib/wb-image-update/zImage"
+case "$ARCH" in
+    arm64)
+        KERNEL_IMAGE_NAME="Image.gz"
+        ;;
+    armhf|armel)
+        KERNEL_IMAGE_NAME="zImage"
+        ;;
+    *)
+        die "Unsupported architecture: $ARCH"
+        ;;
+esac
+
+ROOTFS_BOOTLET_ZIMAGE_PATH="$ROOTFS/var/lib/wb-image-update/$KERNEL_IMAGE_NAME"
 if [[ -e "$ROOTFS_BOOTLET_ZIMAGE_PATH" ]]; then
     echo "Using bootlet zImage from rootfs ($ROOTFS_BOOTLET_ZIMAGE_PATH)"
     ZIMAGE="$ROOTFS_BOOTLET_ZIMAGE_PATH"


### PR DESCRIPTION
Что сделано:

 - выкинута сборка .img для WB8, они там совсем не будут использоваться, прошивка на производстве ставится через fit
 - автоматически ищется `Image.gz` в папке с бутлетом
 - compatible-строка берётся из dtb из бутлета вместо скачанного с S3 (для wb8 не будем выкладывать, это и раньше был костыль)