### PR TITLE
Bugfix/build wb8

### DIFF
--- a/boards/8x.sh
+++ b/boards/8x.sh
@@ -1,11 +1,11 @@
 # Wiren Board 8.0 and newer
 export FORCE_WB_VERSION=
-export DTB=/boot/dtbs/allwinner/sun50i-h616-wirenboard8xx.dtb
+export DTB=/boot/dtbs/allwinner/sun50i-h616-wirenboard843.dtb
 
 board_include soc_sun50i_h616.sh
 
 board_install() {
 	wb-common_install
 
-	set_fdt sun50i-h616-wirenboard8xx
+	set_fdt sun50i-h616-wirenboard843
 }


### PR DESCRIPTION
при сборке fit-а на wb8, wb-configs неправильно разворачивали of_compatible* магию