### PR TITLE
rootfs: mix arch into repo_hash to fix rootfs cache for all/staging

### DIFF
--- a/rootfs/create_rootfs.sh
+++ b/rootfs/create_rootfs.sh
@@ -117,7 +117,7 @@ check_additional_repos() {
 FULL_REPO_URL=`echo "$WB_REPO/$WB_REPO_PREFIX/$WB_TARGET" | sed 's#//\+#/#g' | sed 's#http\(s\)\?:/#http\1://#g'`
 WB_TARGET_FOR_FILENAME=`echo $WB_TARGET | sed 's#/#_#'`
 
-WB_REPO_HASH=`echo "$FULL_REPO_URL $ADD_REPOS" | sha256sum - | head -c 8`
+WB_REPO_HASH=$(echo "$ARCH $FULL_REPO_URL $ADD_REPOS" | sha256sum - | head -c 8)
 ROOTFS_BASE_SUFFIX="${WB_RELEASE}_${WB_TARGET_FOR_FILENAME}_${DEBIAN_RELEASE}_r${WB_REPO_HASH}"
 ROOTFS_BASE_TARBALL="${WORK_DIR}/rootfs_base_${ROOTFS_BASE_SUFFIX}.tar.gz"
 


### PR DESCRIPTION
на CI изначально не работала сборка staging для wb7 и wb8 одновременно, потому что в имени файла с кэшем rootfs никак не была задействована целевая архитектура, из-за чего в прогретом кэше rootfs лежал только один архив со случайной архитектурой (armhf или arm64). соответственно из-за этого одна из целевых версий не собиралась, потому что не могла найти нужные пакеты.

после этого патча должно заработать.