### PR TITLE
devenv: fix compiledb

### DIFF
--- a/devenv/entrypoint.sh
+++ b/devenv/entrypoint.sh
@@ -399,10 +399,7 @@ case "$cmd" in
         chr apt-get update
         chr mk-build-deps -ir -t "apt-get --force-yes -y"
         if [ -f CMakeLists.txt ]; then
-            mkdir -p build
-            pushd build
-            chu cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ..
-            popd
+            chu mkdir -p build; ( cd build && cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .. )
             mv build/compile_commands.json compile_commands.json
         elif [ -f Makefile ]; then
             chu make -Bnwk | compiledb -o compile_commands.json


### PR DESCRIPTION
build создавался от рута и у jenkins юзера не было прав на запись