### PR TITLE
ci: releaseImages: add details to tg alert

### DIFF
--- a/ci/pipelines/releaseImages.groovy
+++ b/ci/pipelines/releaseImages.groovy
@@ -124,12 +124,12 @@ pipeline {
     post {
         always { script {
             if (params.ENABLE_TELEGRAM_ALERT) {
-                wb.notifyMaybeBuildRestored()
+                wb.notifyMaybeBuildRestored("Boards: ${params.BOARDS}, WB release: ${params.WB_RELEASE}")
             }
         }}
         failure { script {
             if (params.ENABLE_TELEGRAM_ALERT) {
-                wb.notifyBuildFailed()
+                wb.notifyBuildFailed("Boards: ${params.BOARDS}, WB release: ${params.WB_RELEASE}")
             }
         }}
     }


### PR DESCRIPTION
Для release-images пайплайна в алерте хочется видеть подробности: как минимум с какими BOARDS и WB_RELEASE параметрами был запущен пайплайн.

Depends on https://github.com/wirenboard/jenkins-pipeline-lib/pull/98
