### PR TITLE
ci: releaseImages: fix test stage names

### DIFF
--- a/ci/pipelines/releaseImages.groovy
+++ b/ci/pipelines/releaseImages.groovy
@@ -73,7 +73,7 @@ pipeline {
                         def currentBoard = item.board
 
                         jobs["test ${currentImageJob.getId()}"] = {
-                            stage("Test ${currentImageJob.getId()}") {
+                            stage("Test ${currentBoard} ${currentImageJob.getId()}") {
                                 build(job: 'pipelines/release-test-orchestrator',
                                       wait: true,
                                       parameters: [


### PR DESCRIPTION
Так как порядок стейджев может быть разный, сходу не очевидно "Test N" это какой борде соответствует:
<img width="825" alt="Näyttökuva 2024-10-3 kello 14 35 29" src="https://github.com/user-attachments/assets/55a9a92e-9c22-4717-b489-8510928f651c">
Например тут 7916 это wb8, 7919 это wb7.