### PR TITLE
devenv: add ccache to chroot

### DIFF
--- a/devenv/entrypoint.sh
+++ b/devenv/entrypoint.sh
@@ -90,6 +90,10 @@ hard_link = false
 umask = 002
 EOF
     export PATH="/usr/lib/ccache:$PATH"
+
+    cp /etc/ccache.conf $ROOTFS/etc/ccache.conf
+    cp /usr/local/bin/ccache-setup $ROOTFS/usr/local/bin/ccache-setup
+    mkdir -p $ROOTFS/var/cache/ccache && chmod 777 $ROOTFS/var/cache/ccache
 fi
 
 rm -f /.devdir $ROOTFS/.devdir

--- a/devenv/prep.sh
+++ b/devenv/prep.sh
@@ -16,8 +16,7 @@ pkgs=(devscripts equivs build-essential \
     pkg-config bash-completion \
     libgtest-dev google-mock cmake \
     cdbs autoconf automake libtool \
-    knxd-dev knxd-tools knxd \
-    git git-man gcc g++
+    git git-man gcc g++ ccache
 )
 
 chr_apt_install "${pkgs[@]}"

--- a/devenv/wbdev_second_half.sh
+++ b/devenv/wbdev_second_half.sh
@@ -50,7 +50,7 @@ elif [[ -z "$DEV_DIR" ]]; then
 fi
 
 if [[ -n "$DEV_CCACHE_VOLUME" ]]; then
-    WBDEV_CCACHE_DIR=${WBDEV_CCACHE_DIR:-/var/cache/ccache}
+    export WBDEV_CCACHE_DIR=${WBDEV_CCACHE_DIR:-/var/cache/ccache}
     VOLUMES="$VOLUMES -v $DEV_CCACHE_VOLUME:$WBDEV_CCACHE_DIR"
 else
     if [[ -n "$WBDEV_CCACHE_DIR" ]]; then


### PR DESCRIPTION
* WBDEV_CCACHE_DIR не передавалось в контейнер, из-за этого вольюм с ccache кешом не использовался
* добавил ccache с конфигом также для chroot