### PR TITLE
sort rootfs files before tgz packing to speedup fit installing

### DIFF
--- a/image/create_update.sh
+++ b/image/create_update.sh
@@ -68,7 +68,11 @@ if [[ -d "$ROOTFS" ]]; then
 
 	echo "Creating rootfs tarball"
 	pushd "$ROOTFS" >/dev/null
-	sudo tar czp --numeric-owner ./ > "$ROOTFS_TARBALL" || die "tarball of $ROOTFS creation failed"
+	# to speedup FIT installing, rootfs files should be sorted (dtbs at the beginning)
+	sorted_files_list=`mktemp`
+	find . | sort > $sorted_files_list
+	sudo tar czpf "$ROOTFS_TARBALL" --numeric-owner --no-recursion --files-from=$sorted_files_list || die "tarball of $ROOTFS creation failed"
+	rm $sorted_files_list
 	popd >/dev/null
 elif [[ -e "$ROOTFS" ]]; then
 	ROOTFS_TARBALL=$ROOTFS


### PR DESCRIPTION
@lostpoint-ru перенес сборку фитов на новую билдноду, и WB стали прошиваться на 30с медленнее. Раскопали - виноват порядок файлов в рутфс (когда dts-ки в начале рутфс - прошивается быстро; когда в конце - медленно)

пот в прошивке есть кусочек, распаковывающий рутфс и проверяющий наличие нужной dts

закрепил порядок

я погонял-попрошивал WB - поломок не заметил