### PR TITLE
devenv: ensure non-interactive behavior while choosing the default action

### DIFF
--- a/devenv/entrypoint.sh
+++ b/devenv/entrypoint.sh
@@ -341,7 +341,7 @@ case "$cmd" in
             chr sh -c "echo '$(get_stable_repo_spec)' > /etc/apt/sources.list.d/wirenboard.list"
         fi
         chr apt-get update
-        chr mk-build-deps -ir -t "apt-get --force-yes -y"
+        chr mk-build-deps -ir -t "apt-get --force-yes -y -o Dpkg::Options::=--force-confdef"
         if [ -f CMakeLists.txt ]; then
             chu mkdir -p build; ( cd build && PKG_CONFIG_PATH=$ROOTFS_PKG_CONFIG_PATH cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .. )
             mv build/compile_commands.json compile_commands.json


### PR DESCRIPTION
Before:
```sh
Setting up mosquitto (2.0.20-1-wb101) ...
Installing new version of config file /etc/init.d/mosquitto ...
Installing new version of config file /etc/logrotate.d/mosquitto ...

Configuration file '/etc/mosquitto/mosquitto.conf'
 ==> Modified (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** mosquitto.conf (Y/I/N/O/D/Z) [default=N] ? dpkg: error processing package mosquitto (--configure):
 end of file on stdin at conffile prompt
Errors were encountered while processing:
 mosquitto
```

After:
```sh
Setting up mosquitto (2.0.20-1-wb101) ...
Installing new version of config file /etc/init.d/mosquitto ...
Installing new version of config file /etc/logrotate.d/mosquitto ...

Configuration file '/etc/mosquitto/mosquitto.conf'
 ==> Modified (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
 ==> Keeping old config file as default.
```