### PR TITLE
ci: buildImage: add board/release to displayName

### DIFF
--- a/ci/pipelines/buildImage.groovy
+++ b/ci/pipelines/buildImage.groovy
@@ -67,6 +67,9 @@ pipeline {
         }
         stage('Build rootfs') {
             steps {
+                script {
+                    currentBuild.displayName = "#${BUILD_NUMBER} (${BOARD}/${WB_RELEASE})"
+                }
                 sh """
                     wbdev root bash -c 'rm -rf ./output/rootfs_wb$BOARD;
                     WB_REPO_PREFIX=$REPO_PREFIX WB_TARGET=$WB_TARGET WB_RELEASE=$WB_RELEASE \\


### PR DESCRIPTION
Чтобы глядя в Build History сразу понимать какой фит собирался:

<img width="432" alt="Näyttökuva 2025-2-27 kello 18 03 33" src="https://github.com/user-attachments/assets/8fa1ed2d-c4ba-41c2-953b-ff5c3bd15a9b" />
