### PR TITLE
reinstall ca-certificates before add repo

### DIFF
--- a/rootfs/create_rootfs.sh
+++ b/rootfs/create_rootfs.sh
@@ -178,6 +178,10 @@ install_contactless_repo() {
     local KEYRING_TMP=/etc/apt/keyrings/contactless-keyring-tmp.gpg
     rm -f ${APT_LIST_TMP_FNAME}
 
+    echo "Reinstall ca-certificates"
+    chr_apt_update
+    chr_apt_install ca-certificates --reinstall
+
     echo "Install initial repos"
     mkdir -p "$(dirname "${OUTPUT}${KEYRING_TMP}")"
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
однажды почему-то перестали собираться все FIT-ы. Симптомы - не собирается рутфс на этапе наливания наших пакетов; см картинку
![image](https://github.com/user-attachments/assets/f455f01f-77a9-4dc2-8be3-7d3683eef9cb)

возможно, как-то связано с недавними интернет-делами

вижу, что дженкинс советует установить ca-certificates. Погуглил интернетовы - оказалось, дженкинс дело говорит. Установка ca-certificates в рутфс перед прописыванием наших репозиториев помогла. Как оно работало раньше - тайна, покрытая мраком...
___________________________________
**Что поменялось для пользователей:**
на fw-releases появятся fit-ы за апрель

___________________________________
**Как проверял/а:**
прописал эту веточку в сборку fit-а; [вот](https://jenkins.wirenboard.com/job/pipelines/job/build-image/10041/parameters/) пруфы
