### PR TITLE
devenv: set DEB_BUILD_OPTIONS

### DIFF
--- a/devenv/wbdev_second_half.sh
+++ b/devenv/wbdev_second_half.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # This file will be executed on host to run docker container
 
-DEB_BUILD_PROFILES=${DEB_BUILD_PROFILES:-"cross"}
+export DEB_BUILD_OPTIONS=${DEB_BUILD_OPTIONS:-}
+export DEB_BUILD_PROFILES=${DEB_BUILD_PROFILES:-"cross"}
 DOCKER=${DOCKER:-"docker"}
 DOCKER_TTY_OPTS=-i
 if [ -t 0 ]; then


### PR DESCRIPTION
### Before
```sh
$ wbdev cdeb
...
< no dh_auto_test >
...
```
```sh
$ DEB_BUILD_OPTIONS= wbdev cdeb
...
   dh_auto_test -a -O--parallel
	make -j8 test
...
```

### After
```sh
$ wbdev cdeb
...
   dh_auto_test -a -O--parallel
	make -j8 test
...
```

### RCA
```sh
$ FOO=; docker run -it -e FOO bash bash -c 'test -v FOO && echo defined || echo not-defined'
not-defined
$ export FOO=; docker run -it -e FOO bash bash -c 'test -v FOO && echo defined || echo not-defined'
defined
```
If DEB_BUILD_OPTIONS is not set, `nocheck` is enabled by default.