### PR TITLE
temporarily disable fixed-release-check

### DIFF
--- a/ci/pipelines/publishImage.groovy
+++ b/ci/pipelines/publishImage.groovy
@@ -49,11 +49,11 @@ pipeline {
                             error('FIT filename parsing failed')
                         }
 
-                        def releaseSuite = sh(returnStdout: true, script: """
-                            wbdev user fdtget -d '' -t s ${fitName} / release-suite""").trim()
-                        if (!["stable", "testing"].contains(releaseSuite)) {
-                            error('release-suite property from FIT file is not stable or testing')
-                        }
+                        // def releaseSuite = sh(returnStdout: true, script: """
+                        //     wbdev user fdtget -d '' -t s ${fitName} / release-suite""").trim()
+                        // if (!["stable", "testing"].contains(releaseSuite)) {
+                        //     error('release-suite property from FIT file is not stable or testing')
+                        // }
 
                         // if release name is wb-XXXX, make image stable
                         def remoteSection = releaseName;


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
недавно @ekateluv внедряла проверочку, что релиз в фите - вида stable/testing, а не wb-2501 (чтобы пользователи потом без проблем обновлялись). Я заметил, что что-то не работает => пусть сама @ekateluv чинит, как вернется

___________________________________
**Что поменялось для пользователей:**
ничего; для нас - fit-ы станут выкладываться на fw-releases

___________________________________
**Как проверял/а:**
собрал FIT, подхакав то же самое через replay в женкинсе - собралось

