### PR TITLE
devenv: cleanup

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -19,7 +19,7 @@ RUN apt update && apt install -y curl wget gnupg && \
     apt update && \
     apt install -y --force-yes git gpg debootstrap proot build-essential pkg-config debhelper \
        nodejs bash-completion nano gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu sudo locales \
-       devscripts python3-virtualenv python3-pip equivs qemu-user-static binfmt-support node-rimraf \
+       devscripts python3-virtualenv python3-pip equivs qemu-user-static binfmt-support \
        libmosquittopp-dev libmosquitto-dev pkg-config gcc g++ libmodbus-dev debian-archive-keyring \
        libcurl4-gnutls-dev libsqlite3-dev libjsoncpp-dev sbuild kpartx zip device-tree-compiler \
        valgrind libgtest-dev google-mock cmake config-package-dev libssl-dev bc lzip lzop \
@@ -80,5 +80,4 @@ ENV LC_ALL en_US.UTF-8
 
 COPY wbdev_profile.sh /etc/profile.d/wbdev_profile.sh
 
-RUN npm install -g bower grunt-cli
 RUN rm -rf /var/lib/apt/lists/*

--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -73,7 +73,7 @@ EOF
 	schroot -c ${CHROOT_NAME} --directory=/ -- apt-get -y install \
 		libssl-dev:arm64 linux-libc-dev:arm64 libc6-dev:arm64 libc-ares2:arm64 \
 		libssl-dev:armhf linux-libc-dev:armhf libc6-dev:armhf libc-ares2:armhf \
-		golang-1.21-go node-rimraf python3-jinja2 \
+		golang-1.21-go python3-jinja2 \
 		"${ADD_PACKAGES[@]}"
 
 	#virtualization support packages


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
* grunt and bower are not used since homeui>=2.0
* rimraf is not used since https://github.com/wirenboard/homeui/pull/734

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


