### PR TITLE
Fix release name check

### DIFF
--- a/ci/pipelines/publishImage.groovy
+++ b/ci/pipelines/publishImage.groovy
@@ -49,11 +49,11 @@ pipeline {
                             error('FIT filename parsing failed')
                         }
 
-                        // def releaseSuite = sh(returnStdout: true, script: """
-                        //     wbdev user fdtget -d '' -t s ${fitName} / release-suite""").trim()
-                        // if (!["stable", "testing"].contains(releaseSuite)) {
-                        //     error('release-suite property from FIT file is not stable or testing')
-                        // }
+                        def releaseSuite = sh(returnStdout: true, script: """
+                            wbdev user fdtget -d '' -t s ${fitName} / release-suite | tail -n 1""").trim()
+                        if (!["stable", "testing"].contains(releaseSuite)) {
+                            error('release-suite property from FIT file is not stable or testing')
+                        }
 
                         // if release name is wb-XXXX, make image stable
                         def remoteSection = releaseName;


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Сломалась проверка имени релиза, потому что на тестовом пайплайне варнинг не попадал в вывод команды и на ревью ошибку не заметили. А на проде попадает. Почему так произошло за пару часов разобраться не получилось, подоткнула тейлом
___________________________________
**Что поменялось для пользователей:**

Заработает проверка
___________________________________
**Как проверял/а:**
Проверила локально что в вывода больше нет варнинга и собрала на тестовом пайплайне
до
```
ekateluv@ekateluv:~/Загрузки$ wbdev user fdtget -d ''  -t s 202504280800_wb-2501_bullseye_wb8x.fit / release-suite
Warning: sbuild+multiarch will be used. Set WBDEV_BUILD_METHOD=qemuchroot for legacy virtualized build.
stable
```
после
```
ekateluv@ekateluv:~/Загрузки$ wbdev user fdtget -d ''  -t s 202504280800_wb-2501_bullseye_wb8x.fit / release-suite | tail -n 1
stable
```
