### PR TITLE
devenv: use WBDEV_USE_UNSTABLE_DEPS for chroot

### DIFF
--- a/devenv/entrypoint.sh
+++ b/devenv/entrypoint.sh
@@ -364,6 +364,11 @@ case "$cmd" in
         ;;
     chroot)
         print_target_info
+        if [ -n "$WBDEV_USE_UNSTABLE_DEPS" ]; then
+            chr sh -c "echo '$(get_unstable_repo_spec)' > /etc/apt/sources.list.d/wirenboard.list"
+        else
+            chr sh -c "echo '$(get_stable_repo_spec)' > /etc/apt/sources.list.d/wirenboard.list"
+        fi
         chr "$@"
         ;;
     *)


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
z2m для сборки использует `wbdev chroot ...`, сейчас понадобилось собрать с nodejs 22, которая есть только тестинге пока. Но WBDEV_USE_UNSTABLE_DEPS не работал для chroot.

___________________________________
**Что поменялось для пользователей:**
Возможность использовать тестинг с `wbdev chroot`.

___________________________________
**Как проверял/а:**

```sh
$ WBDEV_USE_UNSTABLE_DEPS=y ./wbdev chroot bash -c "cat /etc/apt/sources.list.d/wirenboard.list"
Warning: sbuild+multiarch will be used. Set WBDEV_BUILD_METHOD=qemuchroot for legacy virtualized build.
Build target: bullseye-armhf (board wb6)
You can change it by setting WBDEV_TARGET variable (e.g. 'bullseye-armhf'/'bullseye-arm64')
Checking http://deb.wirenboard.com/wb6/bullseye/dists/unstable/Release...
Server returned 301
Platform wb6/bullseye has unstable suite, add it to build
deb [arch=armhf,amd64,arm64] http://deb.wirenboard.com/wb6/bullseye unstable main
$ ./wbdev chroot bash -c "cat /etc/apt/sources.list.d/wirenboard.list"
Warning: sbuild+multiarch will be used. Set WBDEV_BUILD_METHOD=qemuchroot for legacy virtualized build.
Build target: bullseye-armhf (board wb6)
You can change it by setting WBDEV_TARGET variable (e.g. 'bullseye-armhf'/'bullseye-arm64')
Checking http://deb.wirenboard.com/wb6/bullseye/dists/stable/Release...
Server returned 301
Platform wb6/bullseye has stable suite, add it to build
deb [arch=armhf,arm64,amd64] http://deb.wirenboard.com/wb6/bullseye stable main
```
