### PR TITLE
rootfs: add WB_COPY_QEMU flag

### DIFF
--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -8,7 +8,7 @@ do_build() {
 	export RELEASE=$1 ARCH=$2 BOARD=$3 PLATFORM=$4 WB_RELEASE=${5:-stable} ADDITIONAL_REPOS=${*:6}
 	export ROOTFS="/rootfs/$RELEASE-$ARCH"
 
-	time DEBIAN_RELEASE=$RELEASE ARCH=$ARCH WB_RELEASE=$WB_RELEASE /root/rootfs/create_rootfs.sh $BOARD $ADDITIONAL_REPOS
+	time DEBIAN_RELEASE=$RELEASE ARCH=$ARCH WB_RELEASE=$WB_RELEASE WB_COPY_QEMU=true /root/rootfs/create_rootfs.sh $BOARD $ADDITIONAL_REPOS
 
 	rm -f /root/output/rootfs_base_${ARCH}.tar.gz
 	/root/prep.sh

--- a/rootfs/create_rootfs.sh
+++ b/rootfs/create_rootfs.sh
@@ -9,6 +9,7 @@ WB_REPO=${WB_REPO:-'http://deb.wirenboard.com/'}
 WB_REPO_PREFIX=${WB_REPO_PREFIX:-''}
 WB_TEMP_REPO=${WB_TEMP_REPO:-false}
 WB_RELEASE=${WB_RELEASE:-stable}
+WB_COPY_QEMU=${WB_COPY_QEMU:-false}
 
 DEFAULT_ADD_REPO_RELEASE=${ADD_REPO_RELEASE:-$DEBIAN_RELEASE}
 DEFAULT_ADD_REPO_COMPONENT=${ADD_REPO_COMPONENT:-"main"}
@@ -24,6 +25,7 @@ Environment variables:
     WB_RELEASE     Overrides default release (default '$WB_RELEASE')
     WB_TEMP_REPO   Set to 'true' if default repository will be unavailable after build
     DEBIAN_RELEASE Sets Debian release (default '$DEBIAN_RELEASE')
+    WB_COPY_QEMU   Set to 'true' to copy qemu binaries to rootfs (default 'false')
 
 How to use additional repos:
     $0 <BOARD> "http://localhost:8086/" [more repos...]
@@ -230,9 +232,11 @@ else
         --variant=minbase \
         ${DEBIAN_RELEASE} ${OUTPUT} ${REPO}
 
-    echo "Copy qemu to rootfs"
-    cp /usr/bin/qemu-{aarch64,arm}-static ${OUTPUT}/usr/bin ||
-    cp /usr/bin/qemu-{aarch64,arm} ${OUTPUT}/usr/bin
+    if $WB_COPY_QEMU; then
+        echo "Copy qemu to rootfs"
+        cp /usr/bin/qemu-{aarch64,arm}-static ${OUTPUT}/usr/bin ||
+        cp /usr/bin/qemu-{aarch64,arm} ${OUTPUT}/usr/bin
+    fi
     modprobe binfmt_misc || true
 
     # kludge to fix ssmtp configure that breaks when FQDN is unknown


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
На контроллер попадают бинарники qemu, хотя они нужны только в devenv:
```
# file /usr/bin/qemu-*
/usr/bin/qemu-aarch64-static: ELF 64-bit LSB executable, x86-64, version 1 (GNU/Linux), statically linked, BuildID[sha1]=c71526bc9963023bb98aececeab81ffe91f16b47, for GNU/Linux 3.2.0, stripped
/usr/bin/qemu-arm-static:     ELF 64-bit LSB executable, x86-64, version 1 (GNU/Linux), statically linked, BuildID[sha1]=40c96c12d52900a22d8dcd15c383764a70514fba, for GNU/Linux 3.2.0, stripped
# ls -lah /usr/bin/qemu*
-rwxr-xr-x 1 root root  10M May 13 16:59 /usr/bin/qemu-aarch64-static*
-rwxr-xr-x 1 root root 8.7M May 13 16:59 /usr/bin/qemu-arm-static*
```

___________________________________
**Что поменялось для пользователей:**
Немного уменьшился размер фита.

___________________________________
**Как проверял/а:**


