### PR TITLE
rootfs: include ca-certificates for bootstrap packages

### DIFF
--- a/rootfs/create_rootfs.sh
+++ b/rootfs/create_rootfs.sh
@@ -180,10 +180,6 @@ install_contactless_repo() {
     local KEYRING_TMP=/etc/apt/keyrings/contactless-keyring-tmp.gpg
     rm -f ${APT_LIST_TMP_FNAME}
 
-    echo "Reinstall ca-certificates"
-    chr_apt_update
-    chr_apt_install ca-certificates --reinstall
-
     echo "Install initial repos"
     mkdir -p "$(dirname "${OUTPUT}${KEYRING_TMP}")"
 
@@ -230,6 +226,7 @@ else
         --verbose \
         --arch $ARCH \
         --variant=minbase \
+        --include=ca-certificates \
         ${DEBIAN_RELEASE} ${OUTPUT} ${REPO}
 
     if $WB_COPY_QEMU; then


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
в продолжение #232, после недавних шатаний debian-mirror.wirenboard.com перестали собираться rootfs на этапе установки ca-certificates. `--include=ca-certificates` позволяет установить ca-certificates сразу на этапе бутстрапинга.
```
Reinstall ca-certificates

0% [Working]
0% [Working]
0% [Waiting for headers]
0% [Connecting to debian-mirror.wirenboard.com (52.19.109.145)]
                                                               
Err:1 https://debian-mirror.wirenboard.com/debian bullseye InRelease
  Certificate verification failed: The certificate is NOT trusted. The certificate issuer is unknown.  Could not handshake: Error in the certificate verification. [IP: 52.19.109.145 443]
```
___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
собралось на дженкинсе

