### PR TITLE
devenv: fix platform_has_suite

### DIFF
--- a/devenv/entrypoint.sh
+++ b/devenv/entrypoint.sh
@@ -163,7 +163,7 @@ platform_has_suite() {
     local URL="http://deb.wirenboard.com/$(wb_repo_path $PLATFORM)/dists/${SUITE}/Release"
     local HTTP_CODE
     echo "Checking $URL..." >&2
-    HTTP_CODE=`curl --silent --head --output /dev/null --write-out '%{http_code}\n' $URL`
+    HTTP_CODE=`curl --silent --head --location --output /dev/null --write-out '%{http_code}\n' $URL`
     local CURL_STATUS=$?
 
     if [[ "$CURL_STATUS" != "0" ]]; then


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
`platform_has_suite` считает что если ответ [200;400) то сьют есть, а 404 сьюта нет.
Но например в случае редиректа на https:
```sh
curl -sI --output /dev/null --write-out '%{http_code}\n' http://deb.wirenboard.com/wb6/trixie/dists/stable/Release
301
```
Но сьюта не существует:
```sh
curl -sLI --output /dev/null --write-out '%{http_code}\n' http://deb.wirenboard.com/wb6/trixie/dists/stable/Release
404
```
Неверный ответ platform_has_suite далее приводит в добавлению в apt-сорслист несуществующей репы, на чем позднее споткнется apt update.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
на сборке devenv

