### PR TITLE
Remove bullseye-backports apt source

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -15,7 +15,6 @@ RUN apt update && apt install -y curl wget gnupg && \
     curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/apt.llvm.org.gpg && \
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/apt.llvm.org.gpg] http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-15 main" > \
        /etc/apt/sources.list.d/llvm-bullseye-15.list && \
-    echo "deb http://debian-mirror.wirenboard.com/debian bullseye-backports main" > /etc/apt/sources.list.d/bullseye-backports.list && \
     apt update && \
     apt install -y --force-yes git gpg debootstrap proot build-essential pkg-config debhelper \
        nodejs bash-completion nano gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu sudo locales \

--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -50,15 +50,6 @@ Pin: release o=wirenboard
 Pin-Priority: 991
 EOF
 
-	if [[ "$RELEASE" = "bullseye" ]]; then
-		echo "deb http://debian-mirror.wirenboard.com/debian bullseye-backports main" > ${ROOTFS}/etc/apt/sources.list.d/bullseye-backports.list
-		cat <<EOF >${ROOTFS}/etc/apt/preferences.d/bullseye-backports
-Package: libnm0 libmbim-*:any libqmi-*:any gir1.2-mbim-1.0 git1.2-qmi-1.0
-Pin: release a=bullseye-backports
-Pin-Priority: 510
-EOF
-	fi
-
 	# prevent e2fsprogs packages from being installed from wb repo, it messes up with host versions.
 	# it is only needed for actual hardware anyway
 	cat <<EOF >${ROOTFS}/etc/apt/preferences.d/000libext2fs


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Все билды в дженкинсе сломались после удаления bullseye-backports:
```sh
+------------------------------------------------------------------------------+
| Update chroot                                                                |
+------------------------------------------------------------------------------+

Hit:2 https://debian-mirror.wirenboard.com/debian bullseye InRelease
Ign:3 https://debian-mirror.wirenboard.com/debian bullseye-backports InRelease
Err:4 https://debian-mirror.wirenboard.com/debian bullseye-backports Release
  404  Not Found [IP: 45.89.25.184 443]
Get:1 https://deb.wirenboard.com/dev-tools stable InRelease [13.6 kB]
Get:5 https://deb.wirenboard.com/dev-tools stable/main amd64 Packages [27.7 kB]
Get:6 https://deb.wirenboard.com/dev-tools stable/main armhf Packages [18.8 kB]
Get:7 https://deb.wirenboard.com/dev-tools stable/main arm64 Packages [16.9 kB]
Reading package lists...
E: The repository 'http://debian-mirror.wirenboard.com/debian bullseye-backports Release' no longer has a Release file.
...
E: apt-get update failed
...
Finished: FAILURE
```

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
пересобрал devenv

