### PR TITLE
devenv: add WBDEV_USE_UNSTABLE_DEPS support for cdeb+qemuchroot

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # See https://docs.github.com/ for more info about CODEOWNERS syntax
-* @webconn @lostpoint-ru
+* @sikmir @lostpoint-ru

--- a/devenv/entrypoint.sh
+++ b/devenv/entrypoint.sh
@@ -356,6 +356,11 @@ case "$cmd" in
             sbuild_buildpackage ${WBDEV_TARGET_ARCH} "$@"
         else
             if [ "$WBDEV_INSTALL_DEPS" = "yes" ]; then
+                if [ -n "$WBDEV_USE_UNSTABLE_DEPS" ]; then
+                    chr sh -c "echo '$(get_unstable_repo_spec)' > /etc/apt/sources.list.d/wirenboard.list"
+                else
+                    chr sh -c "echo '$(get_stable_repo_spec)' > /etc/apt/sources.list.d/wirenboard.list"
+                fi
                 chr apt-get update
                 chr mk-build-deps -ir -t "apt-get --force-yes -y"
             fi


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Попали в редкую ситуацию, когда dev зависимости для сборки MM в тестинге есть, а в wb-2504 нет (завезли сразу в wb-2507). Казалось бы выставлено `WBDEV_USE_UNSTABLE_DEPS=y`, но как выяснилось оно поддержано только для cdeb+sbuild, но не для cdeb+qemuchroot, а MM как раз тот редкий случай собирается через cdeb+qemuchroot.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
 пересобрал devenv, собрал с ним MM.

