### PR TITLE
devcontainer: add automatic build depends install feature

### DIFF
--- a/vscode/cpp/.devcontainer/devenv-setup.sh
+++ b/vscode/cpp/.devcontainer/devenv-setup.sh
@@ -24,7 +24,7 @@ done
 
 ${CHROOT} bash -c "echo \"deb http://deb.wirenboard.com/${TARGET}/bullseye unstable main\" > /etc/apt/sources.list.d/wirenboard-unstable.list"
 ${CHROOT} apt-get update
-${CHROOT} apt install -y ${DEPS[@]}
+${CHROOT} apt install -y ${DEPS[@]} gdbserver:${ARCH}
 
 apt update
 apt install gdb-multiarch

--- a/vscode/cpp/.devcontainer/devenv-setup.sh
+++ b/vscode/cpp/.devcontainer/devenv-setup.sh
@@ -1,13 +1,30 @@
 #!/bin/bash
 
-schroot -c bullseye-amd64-sbuild --directory=/ -- bash -c 'echo "deb http://deb.wirenboard.com/wb7/bullseye unstable main" > /etc/apt/sources.list.d/wirenboard-unstable.list'
-schroot -c bullseye-amd64-sbuild --directory=/ -- apt-get update
-schroot -c bullseye-amd64-sbuild --directory=/ -- apt-get -y install gdbserver:armhf gcovr:all j2cli:all
-schroot -c bullseye-amd64-sbuild --directory=/ -- apt-get -y install libwbmqtt1-5-test-utils:armhf libdb5.3++-dev:armhf libsqlite3-dev:armhf
+TARGET="wb8"
 
-dir=$(pwd)
-schroot -c bullseye-amd64-sbuild --directory=/ -- mkdir -p $dir
-echo "$dir  $dir   none    rw,bind         0       0" >> /etc/schroot/sbuild/fstab
+case ${TARGET} in
+    wb8) ARCH=arm64 ;;
+    *)   ARCH=armhf ;;
+esac
+
+DIR=$(pwd)
+CHROOT="schroot -c bullseye-amd64-sbuild --directory=${DIR} --"
+
+echo "${DIR} ${DIR} none rw,bind 0 0" >> /etc/schroot/sbuild/fstab
+
+LIST=$(${CHROOT} dpkg-checkbuilddeps 2>&1 | sed 's/dpkg-checkbuilddeps:\serror:\sUnmet build dependencies: //g' | sed 's/[\(][^)]*[\)] *//g')
+DEPS=()
+
+for ITEM in ${LIST}; do
+    if [[ ${ITEM} != *:all ]]; then
+        ITEM+=":${ARCH}"
+    fi
+    DEPS+=(${ITEM})
+done
+
+${CHROOT} bash -c "echo \"deb http://deb.wirenboard.com/${TARGET}/bullseye unstable main\" > /etc/apt/sources.list.d/wirenboard-unstable.list"
+${CHROOT} apt-get update
+${CHROOT} apt install -y ${DEPS[@]}
 
 apt update
 apt install gdb-multiarch


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Для каждого C++ проекта приходится править скрипт сборки devcontainer, чтобы установить нужные зависимости.

___________________________________
**Что поменялось для пользователей:**
Теперь скрипт сам устанавливает зависимости, получая список из секции `Build-Depends` файла `debian/control`.

___________________________________
**Как проверял/а:**
Пересобрал devcontainer для `wb-mqtt-serial` с использованием нового скрипта и проверил что нужные зависимости установились.
