### PR TITLE
Install clang-format-15/clang-tidy-15 explicitly

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -24,7 +24,7 @@ RUN apt update && apt install -y curl wget gnupg && \
        valgrind libgtest-dev google-mock cmake config-package-dev libssl-dev bc lzip lzop \
        python3-netaddr python3-pyparsing libusb-dev libusb-1.0-0-dev jq \
        python3-smbus python3-setuptools liblog4cpp5-dev libpng-dev bison flex kmod dh-python \
-       clang-format clang-tidy lintian ccache \
+       clang-format-15 clang-tidy-15 lintian ccache \
     # for image building \
     fdisk u-boot-tools fit-aligner cpio \
     # legacy requirement for kernel building \
@@ -34,7 +34,10 @@ RUN apt update && apt install -y curl wget gnupg && \
     # to install fpm later for simple package building \
     ruby-rubygems && gem install fpm && \
     # for clang-tidy checks
-    pip3 install compiledb
+    pip3 install compiledb && \
+    # set as defauls
+    update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-15 100 && \
+    update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15 100
 
 # install common build-dependencies
 # TODO: remove it after full migration to sbuild


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Сейчас в devenv подключены apt.llvm.org и [dev-tools](https://deb.wirenboard.com/list.html?prefix=dev-tools/pool/main/l/) репы и clang-format-15 пакет есть в обоих, видимо когда-то давно пытались зафиксировать версию, запушив его и в dev-tools, при этом clang-tidy нет в dev-tools.
Что по факту ставится:
```sh
root@wbdevenv:~# apt policy clang-format
clang-format:
  Installed: 1:15.0-55~20220203224610.5
  Candidate: 1:15.0-55~20220203224610.5
  Version table:
 *** 1:15.0-55~20220203224610.5 500
        500 http://deb.wirenboard.com/dev-tools stable/main amd64 Packages
        100 /var/lib/dpkg/status
     1:11.0-51+nmu5 500
        500 http://deb.debian.org/debian bullseye/main amd64 Packages
root@wbdevenv:~# apt policy clang-format-15
clang-format-15:
  Installed: 1:15.0.7~++20231019083433+8dfdcc7b7bf6-1~exp1~20231019203507.118
  Candidate: 1:15.0.7~++20231019083433+8dfdcc7b7bf6-1~exp1~20231019203507.118
  Version table:
 *** 1:15.0.7~++20231019083433+8dfdcc7b7bf6-1~exp1~20231019203507.118 500
        500 http://apt.llvm.org/bullseye llvm-toolchain-bullseye-15/main amd64 Packages
        100 /var/lib/dpkg/status
     1:15~++20220704093357+5f0a054f8954-1~llvmexp1~20220704093409.365 500
        500 http://deb.wirenboard.com/dev-tools stable/main amd64 Packages
root@wbdevenv:~# apt policy clang-tidy
clang-tidy:
  Installed: 1:11.0-51+nmu5
  Candidate: 1:11.0-51+nmu5
  Version table:
 *** 1:11.0-51+nmu5 500
        500 http://deb.debian.org/debian bullseye/main amd64 Packages
        100 /var/lib/dpkg/status
```
То есть получается clang-format ставится из dev-tools репы, ибо его нет в apt.llvm.org репе, он тянет зависимостью clang-format-15, но этот уже ставится из apt.llvm.org репы, так как в dev-tools версия чуть протухла.
В trixie все это усугубляется тем, что clang-format из стандартной дебиан репы уже 19 версии, соответственно ставится он вместо 15 из apt.llvm.org. А clang-tidy ставился из дебиан репы 11 версии, хотя ожидалось 15 как и clang-format. Вообщем разброд и шатания, лучше тут ставить явно clang-format-15 и clang-tidy-15, а через update-alternatives выставить их дефолтными. 

___________________________________
**Что поменялось для пользователей:**
для bullseye пользователей:
* clang-format - ничего, по прежнему 15 из apt.llvm.org
* clang-tidy: 11 -> 15 (нашел новый ворнинг в сириале про мемлик, но сборку не ломает, можно будет поправить)

для trixie пользователей:
* clang-format: 19 -> 15 (с 19 проверки сломались)
* clang-tidy: 19 -> 15
___________________________________
**Как проверял/а:**
на женкинсе сборка сириала

