### PR TITLE
Fix rootfs build

### DIFF
--- a/rootfs/create_rootfs.sh
+++ b/rootfs/create_rootfs.sh
@@ -181,7 +181,7 @@ run_additional_script() {
 }
 
 install_contactless_repo() {
-    local KEYRING_TMP=/etc/apt/keyrings/contactless-keyring-tmp.gpg
+    local KEYRING_TMP=/etc/apt/trusted.gpg.d/contactless-keyring-tmp.gpg
     rm -f ${APT_LIST_TMP_FNAME}
 
     echo "Install initial repos"
@@ -189,13 +189,11 @@ install_contactless_repo() {
 
     echo 'APT::Key::gpgvcommand "/usr/bin/gpgv";' > ${OUTPUT}/etc/apt/apt.conf.d/99use-gpgv
 
-    chr_apt_update
-    chr_apt_install gnupg1
-
-    chr gpg1 --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AEE07869
-    chr gpg1 --export AEE07869 | tee ${OUTPUT}${KEYRING_TMP}
+    chr gpg1 --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys AEE07869 AA549AA8
+    chr gpg1 --export AEE07869 AA549AA8 > ${OUTPUT}${KEYRING_TMP}
+    chr gpg1 --no-default-keyring --keyring ${KEYRING_TMP} --list-keys
     chmod 0644 "${OUTPUT}${KEYRING_TMP}"
-    echo "deb [signed-by=$KEYRING_TMP] $FULL_REPO_URL $WB_RELEASE main" >  ${APT_LIST_TMP_FNAME}
+    echo "deb $FULL_REPO_URL $WB_RELEASE main" > ${APT_LIST_TMP_FNAME}
 
     chr_apt_update
     chr_apt_install contactless-keyring
@@ -236,7 +234,7 @@ else
         --verbose \
         --arch $ARCH \
         --variant=minbase \
-        --include=ca-certificates,gpgv \
+        --include=ca-certificates,gpgv,gnupg1 \
         ${DEBIAN_RELEASE} ${OUTPUT} ${REPO}
 
     if $WB_COPY_QEMU; then


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
```sh
Install initial repos
Hit:1 http://debian-mirror.wirenboard.com/debian bullseye InRelease
Get:2 http://debian-mirror.wirenboard.com/debian bullseye-updates InRelease [44.0 kB]
Get:3 http://debian-mirror.wirenboard.com/debian-security bullseye-security InRelease [26.0 kB]
Get:4 http://debian-mirror.wirenboard.com/debian bullseye/main Translation-en [6235 kB]
Get:5 http://debian-mirror.wirenboard.com/debian bullseye-updates/main armhf Packages [16.3 kB]
Get:6 http://debian-mirror.wirenboard.com/debian bullseye-updates/main Translation-en [10.9 kB]
Err:3 http://debian-mirror.wirenboard.com/debian-security bullseye-security InRelease
  The following signatures couldn't be verified because the public key is not available: NO_PUBKEY BD4CEEDBAA549AA8
Reading package lists...
```
* bullseye-security теперь подписан ключем BD4CEEDBAA549AA8
* если signed-by не указан явно (как у bullseye-security), то apt смотрит в `/etc/apt/trusted.gpg.d`, но не в `/etc/apt/keyrings`
* ставим gnupg1 сразу при бутстрапе, иначе не сможем обновить bullseye-security из-за отсутствия ключа, а чтобы загрузить ключ нужен gnupg1, замкнутый круг

___________________________________
**Что поменялось для пользователей:**
рутфс собирается

___________________________________
**Как проверял/а:**
сборка фита на дженкинсе

